### PR TITLE
Single place for all the tink stack version

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2.1"
 services:
   tink-server:
-    image: quay.io/tinkerbell/tink:sha-adb49da
+    image: ${TINKERBELL_TINK_SERVER_IMAGE}
     restart: unless-stopped
     environment:
       FACILITY: ${FACILITY:-onprem}
@@ -52,7 +52,7 @@ services:
       retries: 30
 
   tink-cli:
-    image: quay.io/tinkerbell/tink-cli:sha-adb49da
+    image: ${TINKERBELL_TINK_CLI_IMAGE}
     restart: unless-stopped
     environment:
       TINKERBELL_GRPC_AUTHORITY: 127.0.0.1:42113
@@ -89,7 +89,7 @@ services:
     network_mode: host
 
   boots:
-    image: quay.io/tinkerbell/boots:327-58ab49913b5498908b16e2607d265a61a05f73b6
+    image: ${TINKERBELL_TINK_BOOTS_IMAGE}
     restart: unless-stopped
     network_mode: host
     command: -dhcp-addr 0.0.0.0:67 -tftp-addr $TINKERBELL_HOST_IP:69 -http-addr $TINKERBELL_HOST_IP:80 -log-level DEBUG
@@ -133,7 +133,7 @@ services:
       - ./state/webroot:/usr/share/nginx/html/
 
   hegel:
-    image: quay.io/tinkerbell/hegel:196-fa897aa020769db8becb9be29adaeb6be92a7fc7
+    image: ${TINKERBELL_TINK_HEGEL_IMAGE}
     restart: unless-stopped
     network_mode: host
     environment:

--- a/deploy/vagrant/scripts/tinkerbell.sh
+++ b/deploy/vagrant/scripts/tinkerbell.sh
@@ -80,12 +80,12 @@ main() (
 		sudo apt-get install -y jq
 	fi
 
-	if [ ! -f ./envrc ]; then
-		./generate-envrc.sh eth1 >envrc
+	if [ ! -f ./.env ]; then
+		./generate-envrc.sh eth1 > .env
 	fi
 
 	# shellcheck disable=SC1091
-	. ./envrc
+	. ./.env
 
 	make_certs_writable
 

--- a/generate-envrc.sh
+++ b/generate-envrc.sh
@@ -52,6 +52,15 @@ generate_envrc() (
 	local registry_password
 	registry_password=$(generate_password)
 	cat <<EOF
+# Tinkerbell Stack version
+
+export OSIE_DOWNLOAD_LINK=https://tinkerbell-oss.s3.amazonaws.com/osie-uploads/osie-v0-n=252,c=bc454bc,b=master.tar.gz
+export TINKERBELL_TINK_SERVER_IMAGE=quay.io/tinkerbell/tink:sha-adb49da
+export TINKERBELL_TINK_CLI_IMAGE=quay.io/tinkerbell/tink-cli:sha-adb49da
+export TINKERBELL_TINK_BOOTS_IMAGE=quay.io/tinkerbell/boots:327-58ab49913b5498908b16e2607d265a61a05f73b6
+export TINKERBELL_TINK_HEGEL_IMAGE=quay.io/tinkerbell/hegel:196-fa897aa020769db8becb9be29adaeb6be92a7fc7
+export TINKERBELL_TINK_WORKER_IMAGE=quay.io/tinkerbell/tink-worker:sha-adb49da
+
 # Network interface for Tinkerbell's network
 export TINKERBELL_NETWORK_INTERFACE="$tink_interface"
 
@@ -82,14 +91,12 @@ export TINKERBELL_REGISTRY_PASSWORD="$registry_password"
 export FACILITY=onprem
 export ROLLBAR_TOKEN=ignored
 export ROLLBAR_DISABLE=1
-
-export OSIE_DOWNLOAD_LINK=https://tinkerbell-oss.s3.amazonaws.com/osie-uploads/osie-v0-n=252,c=bc454bc,b=master.tar.gz
 EOF
 )
 
 main() (
 	if [ -z "${1:-}" ]; then
-		err "Usage: $0 network-interface-name > envrc"
+		err "Usage: $0 network-interface-name > .env"
 		exit 1
 	fi
 

--- a/setup.sh
+++ b/setup.sh
@@ -8,7 +8,7 @@ set -eu
 # See https://tinkerbell.org/setup for the installation steps.
 
 # file to hold all environment variables
-ENV_FILE=envrc
+ENV_FILE=.env
 
 SCRATCH=$(mktemp -d -t tmp.XXXXXXXXXX)
 readonly SCRATCH
@@ -407,7 +407,7 @@ bootstrap_docker_registry() (
 
     # osie looks for tink-worker:latest, so we have to play with it a bit
     # https://github.com/tinkerbell/osie/blob/master/apps/workflow-helper.sh#L66
-	docker_mirror_image "quay.io/tinkerbell/tink-worker:sha-adb49da" "${TINKERBELL_HOST_IP}/tink-worker:latest"
+	docker_mirror_image "${TINKERBELL_TINK_WORKER_IMAGE}" "${TINKERBELL_HOST_IP}/tink-worker:latest"
 )
 
 setup_docker_registry() (
@@ -482,7 +482,7 @@ check_prerequisites() (
 )
 
 whats_next() (
-	echo "$NEXT  1. Enter /vagrant/deploy and run: source ../envrc; docker-compose up -d"
+	echo "$NEXT  1. Enter /vagrant/deploy and run: source ../.env; docker-compose up -d"
 	echo "$BLANK 2. Try executing your fist workflow."
 	echo "$BLANK    Follow the steps described in https://tinkerbell.org/examples/hello-world/ to say 'Hello World!' with a workflow."
 )

--- a/test/_vagrant/vagrant_test.go
+++ b/test/_vagrant/vagrant_test.go
@@ -35,7 +35,7 @@ func TestVagrantSetupGuide(t *testing.T) {
 		}
 	}()
 
-	_, err = machine.Exec(ctx, "cd /vagrant/deploy && source ../envrc && docker-compose up -d")
+	_, err = machine.Exec(ctx, "cd /vagrant/deploy && source ../.env && docker-compose up -d")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Tinkerbell is made of different components as we all know at this point.

Sandbox had those versions all over the places. This PR moves them as
part of the `envrc` file.

As it is today this PR requires an additional flag for the `docker-compose` command as described here #6 