### PR TITLE
Vagrant virtualbox worker env override fixes

### DIFF
--- a/deploy/vagrant/Vagrantfile
+++ b/deploy/vagrant/Vagrantfile
@@ -1,9 +1,15 @@
 ENV['VAGRANT_NO_PARALLEL'] = 'yes'
 
-# Returns true if `GUI` environment variable is set to a non-empty value.
+# Returns true if `GUI` environment variable exists, value does not matter.
 # Defaults to false
 def worker_gui_enabled?
-  ENV.fetch('VAGRANT_WORKER_GUI', '').empty?
+  ENV.include?('VAGRANT_WORKER_GUI')
+end
+
+# Returns true if `SCALE` environment variable exists, value does not matter.
+# Defaults to false
+def worker_display_scale_enabled?
+  ENV.include?('VAGRANT_WORKER_SCALE')
 end
 
 Vagrant.configure('2') do |config|
@@ -57,6 +63,10 @@ Vagrant.configure('2') do |config|
       vb.memory = 4*1024
       vb.cpus = 1
       vb.gui = worker_gui_enabled?
+      vb.customize [
+        'setextradata', :id,
+        'GUI/ScaleFactor', '3.0'
+      ] if worker_display_scale_enabled?
       vb.customize [
         'modifyvm', :id,
         '--nic1', 'none',

--- a/test/_vagrant/vagrant_test.go
+++ b/test/_vagrant/vagrant_test.go
@@ -95,7 +95,6 @@ func TestVagrantSetupGuide(t *testing.T) {
 
 	t.Logf("WorkflowID: %s", workflowID)
 
-	os.Setenv("VAGRANT_WORKER_GUI", "false")
 	worker, err := vagrant.Up(ctx,
 		vagrant.WithLogger(t.Logf),
 		vagrant.WithMachineName("worker"),


### PR DESCRIPTION
## Description

* Change ENV var check to only validate the existence of the
  var in the local env
* Add VAGRANT_WORKER_SCALE env variable override to control
  GUI scaling for virtualbox

## Why is this needed

It was unnecessary to check for the value of the existing VAGRANT_WORKER_GUI variable
so we can get away with only checking for the existence of the variable in the environment.

Additionally, for folks on high resolution displays, you can set VAGRANT_WORKER_SCALE
and a 300% display scaling will be enabled for the virtualbox worker.

## How Has This Been Tested?

Local (OSX) testing with virtualbox with both vars in the environment, each var individually
in the environment, etc.

## How are existing users impacted? What migration steps/scripts do we need?

Nothing should change for existing users.

## Checklist:

I have:

- [NA] updated the documentation and/or roadmap (if required)
- [NA] added unit or e2e tests
- [NA] provided instructions on how to upgrade
