### PR TITLE
Use variables set in current_versions.sh as part of script/release-binaries.sh

### DIFF
--- a/current_versions.sh
+++ b/current_versions.sh
@@ -7,6 +7,6 @@
 export OSIE_DOWNLOAD_LINK=https://tinkerbell-oss.s3.amazonaws.com/osie-uploads/osie-v0-n=366,c=1aec189,b=master.tar.gz
 export TINKERBELL_TINK_SERVER_IMAGE=quay.io/tinkerbell/tink:sha-0e8e5733
 export TINKERBELL_TINK_CLI_IMAGE=quay.io/tinkerbell/tink-cli:sha-0e8e5733
-export TINKERBELL_TINK_BOOTS_IMAGE=quay.io/tinkerbell/boots:sha-e81a291c
+export TINKERBELL_TINK_BOOTS_IMAGE=quay.io/tinkerbell/boots:sha-9625559b
 export TINKERBELL_TINK_HEGEL_IMAGE=quay.io/tinkerbell/hegel:sha-c17b512f
 export TINKERBELL_TINK_WORKER_IMAGE=quay.io/tinkerbell/tink-worker:sha-0e8e5733

--- a/script/release-binaries.sh
+++ b/script/release-binaries.sh
@@ -4,25 +4,25 @@ source ./current_versions.sh
 
 go run cmd/getbinariesfromquay/main.go \
 	-binary-to-copy /usr/bin/hegel \
-	-image docker://quay.io/tinkerbell/hegel:sha-c17b512f \
+	-image ${TINKERBELL_TINK_HEGEL_IMAGE} \
 	-program hegel
 
 go run cmd/getbinariesfromquay/main.go \
 	-binary-to-copy /usr/bin/boots \
-	-image docker://quay.io/tinkerbell/boots:sha-e81a291c \
+	-image ${TINKERBELL_TINK_BOOTS_IMAGE} \
 	-program boots
 
 go run cmd/getbinariesfromquay/main.go \
 	-binary-to-copy /usr/bin/tink-worker \
-	-image docker://quay.io/tinkerbell/tink-worker:sha-0e8e5733 \
+	-image ${TINKERBELL_TINK_WORKER_IMAGE} \
 	-program tink-worker
 
 go run cmd/getbinariesfromquay/main.go \
 	-binary-to-copy /usr/bin/tink-server \
-	-image docker://quay.io/tinkerbell/tink:sha-0e8e5733 \
+	-image ${TINKERBELL_TINK_SERVER_IMAGE} \
 	-program tink-server
 
 go run cmd/getbinariesfromquay/main.go \
 	-binary-to-copy /usr/bin/tink \
-	-image docker://quay.io/tinkerbell/tink-cli:sha-0e8e5733 \
+	-image ${TINKERBELL_TINK_CLI_IMAGE} \
 	-program tink


### PR DESCRIPTION
When writing the release-binary bash script I didn't use the right
variables in current_versions.sh but I fixed those values as part of the
script itself.
