### PR TITLE
For Unix-style line endings for scripts, add .env to .gitignore

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Use Unix line endings for scripts
+*.sh text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 envrc
 out
+.env


### PR DESCRIPTION
## Description

This PR forces Unix-style checkout for `.sh` files, and adds the `.env` file to `.gitignore`.

## Why is this needed

Cloning the sandbox repository on Windows and running `vagrant up provisioner` eventually fails like this:

```
[...]
    provisioner: + ./generate-envrc.sh eth1
    provisioner: /usr/bin/env: ‘bash\r’: No such file or directory
The SSH command responded with a non-zero exit status. Vagrant
assumes that this means the command failed. The output for this command
should be in the log above. Please read the output to determine what
went wrong.
```

This is because the `.sh` files are treated as text files by git, and the line endings are converted to `crlf` on Windows. Because the `.sh` files are mounted into the Linux guest VMs, they would end up as with the `crlf` line ending on Linux, causing `vagrant up` to fail.

## How Has This Been Tested?

Tested locally.

Because the scripts create symlinks in the `/vagrant` folder, you need to make sure that [your Windows user has permissions to create symbolic links](https://superuser.com/questions/124679/how-do-i-create-a-link-in-windows-7-home-premium-as-a-regular-user?answertab=votes#125981)

## How are existing users impacted? What migration steps/scripts do we need?

Fixes a bug.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
