### PR TITLE
provisioner setup changes to enable NAT for workers

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -487,6 +487,12 @@ whats_next() (
 	echo "$BLANK    Follow the steps described in https://tinkerbell.org/examples/hello-world/ to say 'Hello World!' with a workflow."
 )
 
+setup_nat() (
+	iptables -A FORWARD -i eth1 -o eth0 -j ACCEPT
+	iptables -A FORWARD -i eth0 -o eth1 -m state --state ESTABLISHED,RELATED -j ACCEPT
+	iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE
+)
+
 do_setup() (
 	# perform some very rudimentary platform detection
 	lsb_dist=$(get_distribution)
@@ -504,7 +510,7 @@ do_setup() (
 	source "$ENV_FILE"
 
 	setup_networking "$lsb_dist" "$lsb_version"
-
+	setup_nat
 	setup_osie
 	generate_certificates
 	setup_docker_registry


### PR DESCRIPTION
## Description

Provisioner NAT setup for workers 

## Why is this needed

internet access on workers 
https://github.com/tinkerbell/sandbox/issues/31 


Fixes: #

## How Has This Been Tested?

- workflow executed successfully.
- ping from workers works correctly.

PR in reference with https://github.com/tinkerbell/tink/pull/410 