### PR TITLE
getbinariesfromquay: Remove - separating arch from variant

### DIFF
--- a/cmd/getbinariesfromquay/main.go
+++ b/cmd/getbinariesfromquay/main.go
@@ -88,7 +88,7 @@ func main() {
 		}
 		if arch.Platform.Variant != "" {
 			syss.VariantChoice = arch.Platform.Variant
-			imgDir = imgDir + "-" + arch.Platform.Variant
+			imgDir = imgDir + arch.Platform.Variant
 		}
 		archImg, err := docker.ImageFromName(ctx, syss, imageR)
 		if err != nil {


### PR DESCRIPTION
## Description

Renames binaries to be more consistent in and of itself and also compared to other Go projects that provide multi-arch binaries.

## Why is this needed

@gianarb asked me to rename the binaries in https://github.com/tinkerbell/boots/pull/122 to match this scheme, but I think that this PR is the better directon.