### PR TITLE
Update boots

### DIFF
--- a/current_versions.sh
+++ b/current_versions.sh
@@ -7,6 +7,6 @@
 export OSIE_DOWNLOAD_LINK="https://tinkerbell-oss.s3.amazonaws.com/osie-uploads/osie-v0-n=404,c=c35a5f8,b=master.tar.gz"
 export TINKERBELL_TINK_SERVER_IMAGE=quay.io/tinkerbell/tink:sha-57eb0efb
 export TINKERBELL_TINK_CLI_IMAGE=quay.io/tinkerbell/tink-cli:sha-57eb0efb
-export TINKERBELL_TINK_BOOTS_IMAGE=quay.io/tinkerbell/boots:sha-a449ad23
+export TINKERBELL_TINK_BOOTS_IMAGE=quay.io/tinkerbell/boots:sha-62ed4b82
 export TINKERBELL_TINK_HEGEL_IMAGE=quay.io/tinkerbell/hegel:sha-c8a68311
 export TINKERBELL_TINK_WORKER_IMAGE=quay.io/tinkerbell/tink-worker:sha-57eb0efb


### PR DESCRIPTION
## Description

Update boots version.

## Why is this needed

This will get us proper binaries in the releases but also 64bit boots
for 64bit x86 machines!

## How Has This Been Tested?

Boots has been tested on EM hw.