### PR TITLE
Fix NAT and make it working for Terraform and Vagrant

### DIFF
--- a/deploy/terraform/main.tf
+++ b/deploy/terraform/main.tf
@@ -68,6 +68,14 @@ resource "null_resource" "tink_directory" {
 
   provisioner "remote-exec" {
     inline = [
+      "iptables -A FORWARD -i eth1 -o bond0 -j ACCEPT",
+      "iptables -A FORWARD -i bond0 -o eth1 -m state --state ESTABLISHED,RELATED -j ACCEPT",
+      "iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE",
+    ]
+  }
+
+  provisioner "remote-exec" {
+    inline = [
       "chmod +x /root/tink/*.sh /root/tink/deploy/tls/*.sh"
     ]
   }

--- a/deploy/vagrant/scripts/tinkerbell.sh
+++ b/deploy/vagrant/scripts/tinkerbell.sh
@@ -63,6 +63,12 @@ configure_vagrant_user() (
 			--password-stdin "$TINKERBELL_HOST_IP"
 )
 
+setup_nat() (
+	iptables -A FORWARD -i eth1 -o eth0 -j ACCEPT
+	iptables -A FORWARD -i eth0 -o eth1 -m state --state ESTABLISHED,RELATED -j ACCEPT
+	iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE
+)
+
 main() (
 	export DEBIAN_FRONTEND=noninteractive
 
@@ -90,6 +96,8 @@ main() (
 	make_certs_writable
 
 	./setup.sh
+
+    setup_nat
 
 	secure_certs
 

--- a/setup.sh
+++ b/setup.sh
@@ -487,12 +487,6 @@ whats_next() (
 	echo "$BLANK    Follow the steps described in https://tinkerbell.org/examples/hello-world/ to say 'Hello World!' with a workflow."
 )
 
-setup_nat() (
-	iptables -A FORWARD -i eth1 -o eth0 -j ACCEPT
-	iptables -A FORWARD -i eth0 -o eth1 -m state --state ESTABLISHED,RELATED -j ACCEPT
-	iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE
-)
-
 do_setup() (
 	# perform some very rudimentary platform detection
 	lsb_dist=$(get_distribution)
@@ -510,7 +504,6 @@ do_setup() (
 	source "$ENV_FILE"
 
 	setup_networking "$lsb_dist" "$lsb_version"
-	setup_nat
 	setup_osie
 	generate_certificates
 	setup_docker_registry


### PR DESCRIPTION
Commit b504810 introduced a NAT to make worker capable of reaching the
public internet via the provisioner.

But it also introduced a bug, it only works for the Vagrant setup as
Manny pointed out:

https://github.com/tinkerbell/sandbox/pull/33#issuecomment-759651035

This is an attempt to fix it

@mmlb I would like to avoid additional conditions as part of the
setup.sh, we have already too many of them and they are not even easy to
dsicover. We have different entrypoint for those environment let's use them.
