### PR TITLE
Fix vagrant config for libvirt

### DIFF
--- a/deploy/vagrant/Vagrantfile
+++ b/deploy/vagrant/Vagrantfile
@@ -22,8 +22,12 @@ Vagrant.configure('2') do |config|
 
     provisioner.vm.network :private_network,
                         virtualbox__intnet: "tink_network",
+                        libvirt__network_name: "tink_network",
+                        libvirt__host_ip: "192.168.1.6",
+                        libvirt__netmask: "255.255.255.248",
                         libvirt__dhcp_enabled: false,
                         libvirt__forward_mode: 'none',
+                        libvirt__adapter: 1,
                         auto_config: false
 
     provisioner.vm.network "forwarded_port", guest: 42113, host: 42113
@@ -47,6 +51,7 @@ Vagrant.configure('2') do |config|
     worker.vm.network :private_network,
                       mac: "080027000001",
                       virtualbox__intnet: "tink_network",
+                      libvirt__network_name: "tink_network",
                       libvirt__dhcp_enabled: false,
                       libvirt__forward_mode: 'none',
                       auto_config: false
@@ -56,6 +61,8 @@ Vagrant.configure('2') do |config|
       lv.cpus = 1
       lv.boot 'network'
       lv.mgmt_attach = false
+      lv.storage :file, :size => '40G'
+      lv.random :model => 'random'
     end
 
     worker.vm.provider :virtualbox do |vb, worker|


### PR DESCRIPTION
## Description

Fixes the vagrant configuration when using libvirt

## Why is this needed

Without this issue the vagrant provisioner fails when using libvirt with the following error:

```sh
Error occurred while creating new network: {:iface_type=>:private_network, :netmask=>"255.255.255.0", :dhcp_enabled=>false, :forward_mode=>"none", :virtualbox__intnet=>"tink_network", :libvirt__dhcp_enabled=>false, :libvirt__forward_mode=>"none", :auto_config=>false, :protocol=>"tcp", :id=>"18e6fc6d-41b8-40c9-814d-ffc476bfd920"}.
```

## How Has This Been Tested?

Reran vagrant up after making the changes and the provisioner machine successfully was created


## How are existing users impacted? What migration steps/scripts do we need?

Should not affect existing users unless they were trying to use vagrant/libvirt and were unsuccessful before.

No migration should be needed.

