### PR TITLE
Use same IP address for both boots and nginx

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -124,7 +124,7 @@ services:
       PACKET_VERSION: ${PACKET_VERSION:-ignored}
       ROLLBAR_TOKEN: ${ROLLBAR_TOKEN:-ignored}
       ROLLBAR_DISABLE: ${ROLLBAR_DISABLE:-1}
-      MIRROR_HOST: ${TINKERBELL_NGINX_IP:-127.0.0.1}
+      MIRROR_HOST: ${TINKERBELL_HOST_IP:-127.0.0.1}:8080
       DNS_SERVERS: 8.8.8.8
       PUBLIC_IP: $TINKERBELL_HOST_IP
       BOOTP_BIND: $TINKERBELL_HOST_IP:67
@@ -151,7 +151,7 @@ services:
     restart: unless-stopped
     tty: true
     ports:
-      - $TINKERBELL_NGINX_IP:80:80/tcp
+      - $TINKERBELL_HOST_IP:8080:80/tcp
     volumes:
       - ./state/webroot:/usr/share/nginx/html/
 

--- a/generate-envrc.sh
+++ b/generate-envrc.sh
@@ -78,9 +78,6 @@ export TINKERBELL_CIDR=29
 # should be the second address.
 export TINKERBELL_HOST_IP=192.168.1.1
 
-# NGINX IP is used by provisioner to serve files required for iPXE boot
-export TINKERBELL_NGINX_IP=192.168.1.2
-
 # Tink server username and password
 export TINKERBELL_TINK_USERNAME=admin
 export TINKERBELL_TINK_PASSWORD="$tink_password"


### PR DESCRIPTION
Signed-off-by: Michael Richard <michael.richard.ing@gmail.com>

## Description

This configures NGINX to listen on port 8080 and lets go the need to configure a second IP address on the host dedicated to NGINX.

## Why is this needed

Setting up a second IP address to host NGINX on the same host is not always easy, especially when running tinkerbell on network devices like switches. The second IP address adds a useless level of complexity. In the future, all the code required to identify the host operating system and configure the IP address could even be removed and left as a prerequisite, since the host is likely to have an IP address already configured.

## How Has This Been Tested?

The untouched vagrant_test.go test ran sucessfully.

## How are existing users impacted? What migration steps/scripts do we need?

Simply re-applying the docker-compose.yml should be sufficient (untested).
Additional firewall rules to allow traffic on port 8080 could be required depending on user's network configuration.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
