### PR TITLE
Install local tink cli for Vagrant setup

### DIFF
--- a/current_versions.sh
+++ b/current_versions.sh
@@ -4,6 +4,7 @@
 # automation that needs to get the version of the programs currently supported
 # in sandbox
 
+export TINKERBELL_SANDBOX_VERSION="0.4.0"
 export OSIE_DOWNLOAD_LINK="https://tinkerbell-oss.s3.amazonaws.com/osie-uploads/osie-v0-n=404,c=c35a5f8,b=master.tar.gz"
 export TINKERBELL_TINK_SERVER_IMAGE=quay.io/tinkerbell/tink:sha-57eb0efb
 export TINKERBELL_TINK_CLI_IMAGE=quay.io/tinkerbell/tink-cli:sha-57eb0efb

--- a/deploy/vagrant/scripts/tinkerbell.sh
+++ b/deploy/vagrant/scripts/tinkerbell.sh
@@ -31,6 +31,13 @@ setup_nat() (
 	iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE
 )
 
+get_tink_cli() {
+	sudo wget -O /usr/local/bin/tink \
+	"https://github.com/tinkerbell/sandbox/releases/download/v$TINKERBELL_SANDBOX_VERSION/tink-linux-386"
+	sudo chmod 755 /usr/local/bin/tink
+	sudo chown "root" /usr/local/bin/tink
+}
+
 main() (
 	export DEBIAN_FRONTEND=noninteractive
 
@@ -44,6 +51,8 @@ main() (
 	make_certs_writable
 
 	./setup.sh
+
+	get_tink_cli
 
 	setup_nat
 	secure_certs

--- a/generate-envrc.sh
+++ b/generate-envrc.sh
@@ -56,6 +56,7 @@ generate_envrc() (
 	cat <<EOF
 # Tinkerbell Stack version
 
+export TINKERBELL_SANDBOX_VERSION=${TINKERBELL_SANDBOX_VERSION}
 export OSIE_DOWNLOAD_LINK=${OSIE_DOWNLOAD_LINK}
 export TINKERBELL_TINK_SERVER_IMAGE=${TINKERBELL_TINK_SERVER_IMAGE}
 export TINKERBELL_TINK_CLI_IMAGE=${TINKERBELL_TINK_CLI_IMAGE}
@@ -81,6 +82,10 @@ export TINKERBELL_HOST_IP=192.168.1.1
 # Tink server username and password
 export TINKERBELL_TINK_USERNAME=admin
 export TINKERBELL_TINK_PASSWORD="$tink_password"
+
+# Tink cli: Tink Server location and CERT
+export TINKERBELL_GRPC_AUTHORITY=127.0.0.1:42113
+export TINKERBELL_CERT_URL=http://127.0.0.1:42114/cert
 
 # Docker Registry's username and password
 export TINKERBELL_REGISTRY_USERNAME=admin


### PR DESCRIPTION
## Description

**DO NOT COMMIT!! Still working on it!**

Install Tink CLI from Sandbox Github Release location to main Vagrant or Provisioning VM so a docker cli line isn't needed any more.

## Why is this needed

Implements #49 

Fixes: #49 

## How Has This Been Tested?

This PR is hand tested as I don't have access to a Vagrant or Terraform installation

## How are existing users impacted? What migration steps/scripts do we need?

None, this is just an add-on to the normal Vagrant and Terraform install flow

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
