### PR TITLE
Removes conflicting composefile network instruction per #53 for boots…

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -114,7 +114,6 @@ services:
   boots:
     image: ${TINKERBELL_TINK_BOOTS_IMAGE}
     restart: unless-stopped
-    network_mode: host
     command: -dhcp-addr 0.0.0.0:67 -tftp-addr $TINKERBELL_HOST_IP:69 -http-addr $TINKERBELL_HOST_IP:80 -log-level DEBUG
     environment:
       API_AUTH_TOKEN: ${PACKET_API_AUTH_TOKEN:-ignored}


### PR DESCRIPTION
… container definition

## Description

Resolves #53 

## Why is this needed

This conflict causes container creation to fail. 

Fixes: #

## How Has This Been Tested?

I ran the setup and was able to run a workflow and deployment without issue.

## How are existing users impacted? What migration steps/scripts do we need?

No impact.


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
