### PR TITLE
Fix port collision between boots and nginx

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -114,7 +114,7 @@ services:
   boots:
     image: ${TINKERBELL_TINK_BOOTS_IMAGE}
     restart: unless-stopped
-    command: -dhcp-addr 0.0.0.0:67 -tftp-addr $TINKERBELL_HOST_IP:69 -http-addr $TINKERBELL_HOST_IP:80 -log-level DEBUG
+    network_mode: host
     environment:
       API_AUTH_TOKEN: ${PACKET_API_AUTH_TOKEN:-ignored}
       API_CONSUMER_TOKEN: ${PACKET_CONSUMER_TOKEN:-ignored}
@@ -126,10 +126,10 @@ services:
       MIRROR_HOST: ${TINKERBELL_HOST_IP:-127.0.0.1}:8080
       DNS_SERVERS: 8.8.8.8
       PUBLIC_IP: $TINKERBELL_HOST_IP
-      BOOTP_BIND: $TINKERBELL_HOST_IP:67
-      HTTP_BIND: $TINKERBELL_HOST_IP:80
-      SYSLOG_BIND: $TINKERBELL_HOST_IP:514
-      TFTP_BIND: $TINKERBELL_HOST_IP:69
+      BOOTP_BIND: :67
+      HTTP_BIND: :80
+      SYSLOG_BIND: :514
+      TFTP_BIND: :69
       DOCKER_REGISTRY: $TINKERBELL_HOST_IP
       REGISTRY_USERNAME: $TINKERBELL_REGISTRY_USERNAME
       REGISTRY_PASSWORD: $TINKERBELL_REGISTRY_PASSWORD
@@ -140,17 +140,13 @@ services:
     depends_on:
       db:
         condition: service_healthy
-    ports:
-      - $TINKERBELL_HOST_IP:80:80/tcp
-      - 67:67/udp
-      - 69:69/udp
 
   nginx:
     image: nginx:alpine
     restart: unless-stopped
     tty: true
     ports:
-      - $TINKERBELL_HOST_IP:8080:80/tcp
+      - 8080:80/tcp
     volumes:
       - ./state/webroot:/usr/share/nginx/html/
 


### PR DESCRIPTION
I am not sure when it happens, it can be when we removed the NGINX_IP,
or when we checked that every services were using ports OR network_mode
but we exposed nginx and boots over the same port.

This commit fixes that.
