### PR TITLE
add current_versions.sh file to the terraform provisioner

### DIFF
--- a/deploy/terraform/main.tf
+++ b/deploy/terraform/main.tf
@@ -62,6 +62,11 @@ resource "null_resource" "tink_directory" {
   }
 
   provisioner "file" {
+    source      = "../../current_versions.sh"
+    destination = "/root/tink/current_versions.sh"
+  }
+
+  provisioner "file" {
     source      = "../../deploy"
     destination = "/root/tink"
   }


### PR DESCRIPTION
## Description
Mounting the `current_versions.sh` file to the target provisioner when installing TinkerBell on Equinix using terraform 
<!--- Please describe what this PR is going to change -->

## Why is this needed
Because the `generate-envrc.sh` will fail and no TinkerBell env will be created.
<!--- Link to issue you have raised -->

Fixes: #60

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Simply ran the provisioner on Equinix and the env file was created with all the needed info.

## How are existing users impacted? What migration steps/scripts do we need?
None
<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
