### PR TITLE
Bump tink stack to newest version

### DIFF
--- a/current_versions.sh
+++ b/current_versions.sh
@@ -6,9 +6,9 @@
 # automation that wants to get the version of the programs currently supported
 # in sandbox
 
-export OSIE_DOWNLOAD_LINK="https://tinkerbell-oss.s3.amazonaws.com/osie-uploads/osie-v0-n=404,c=c35a5f8,b=master.tar.gz"
-export TINKERBELL_TINK_BOOTS_IMAGE="quay.io/tinkerbell/boots:sha-70440b27"
-export TINKERBELL_TINK_CLI_IMAGE="quay.io/tinkerbell/tink-cli:sha-a7e947ef"
+export OSIE_DOWNLOAD_LINK="https://tinkerbell-oss.s3.amazonaws.com/osie-uploads/osie-v0-n=448,c=6bf665c,b=master.tar.gz"
+export TINKERBELL_TINK_BOOTS_IMAGE="quay.io/tinkerbell/boots:sha-ad742e11"
+export TINKERBELL_TINK_CLI_IMAGE="quay.io/tinkerbell/tink-cli:sha-1b178dae"
 export TINKERBELL_TINK_HEGEL_IMAGE="quay.io/tinkerbell/hegel:sha-c8a68311"
-export TINKERBELL_TINK_SERVER_IMAGE="quay.io/tinkerbell/tink:sha-a7e947ef"
-export TINKERBELL_TINK_WORKER_IMAGE="quay.io/tinkerbell/tink-worker:sha-a7e947ef"
+export TINKERBELL_TINK_SERVER_IMAGE="quay.io/tinkerbell/tink:sha-1b178dae"
+export TINKERBELL_TINK_WORKER_IMAGE="quay.io/tinkerbell/tink-worker:sha-1b178dae"


### PR DESCRIPTION
In preparation for v0.5.0 let's bump a few dependencies up to the newest
versions
