### PR TITLE
pin boots to TINKERBELL_HOST_IP instead of 0.0.0.0

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -115,6 +115,7 @@ services:
     image: ${TINKERBELL_TINK_BOOTS_IMAGE}
     restart: unless-stopped
     network_mode: host
+    command: -dhcp-addr 0.0.0.0:67 -tftp-addr $TINKERBELL_HOST_IP:69 -http-addr $TINKERBELL_HOST_IP:80 -log-level DEBUG
     environment:
       API_AUTH_TOKEN: ${PACKET_API_AUTH_TOKEN:-ignored}
       API_CONSUMER_TOKEN: ${PACKET_CONSUMER_TOKEN:-ignored}
@@ -126,10 +127,10 @@ services:
       MIRROR_HOST: ${TINKERBELL_HOST_IP:-127.0.0.1}:8080
       DNS_SERVERS: 8.8.8.8
       PUBLIC_IP: $TINKERBELL_HOST_IP
-      BOOTP_BIND: :67
-      HTTP_BIND: :80
-      SYSLOG_BIND: :514
-      TFTP_BIND: :69
+      BOOTP_BIND: $TINKERBELL_HOST_IP:67
+      HTTP_BIND: $TINKERBELL_HOST_IP:80
+      SYSLOG_BIND: $TINKERBELL_HOST_IP:514
+      TFTP_BIND: $TINKERBELL_HOST_IP:69
       DOCKER_REGISTRY: $TINKERBELL_HOST_IP
       REGISTRY_USERNAME: $TINKERBELL_REGISTRY_USERNAME
       REGISTRY_PASSWORD: $TINKERBELL_REGISTRY_PASSWORD
@@ -140,6 +141,10 @@ services:
     depends_on:
       db:
         condition: service_healthy
+    ports:
+      - $TINKERBELL_HOST_IP:80:80/tcp
+      - 67:67/udp
+      - 69:69/udp
 
   nginx:
     image: nginx:alpine


### PR DESCRIPTION
## Description

Reverts the docker-compose file back to pinning boots to TINKERBELL_HOST_IP rather than binding to 0.0.0.0

## Why is this needed

Without this it appears that hosts that may have multiple IPs (such as a bare metal host that tinkerbell has been deployed on) fail to properly tftp files to hosts if the traffic enters/leaves the host through separate IPs. For example my host has a static IP of 192.168.1.5 before deploying the sandbox on it. Afterwards it also has 192.168.1.1. Without this change tftp requests from the host during pxe booting timeout and fail. With this change the tftp requests succeed.

## How Has This Been Tested?

Tested manually on a physical host that is running Tinkerbell from sandbox

## How are existing users impacted? What migration steps/scripts do we need?

This should not affect existing users since it reverts back to pre-existing behavior

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
