### PR TITLE
Revert osie because the latest version broke tink-worker installation

### DIFF
--- a/current_versions.sh
+++ b/current_versions.sh
@@ -6,7 +6,7 @@
 # automation that wants to get the version of the programs currently supported
 # in sandbox
 
-export OSIE_DOWNLOAD_LINK="https://tinkerbell-oss.s3.amazonaws.com/osie-uploads/osie-v0-n=448,c=6bf665c,b=master.tar.gz"
+export OSIE_DOWNLOAD_LINK="https://tinkerbell-oss.s3.amazonaws.com/osie-uploads/osie-v0-n=404,c=c35a5f8,b=master.tar.gz"
 export TINKERBELL_TINK_BOOTS_IMAGE="quay.io/tinkerbell/boots:sha-ad742e11"
 export TINKERBELL_TINK_CLI_IMAGE="quay.io/tinkerbell/tink-cli:sha-1b178dae"
 export TINKERBELL_TINK_HEGEL_IMAGE="quay.io/tinkerbell/hegel:sha-c8a68311"


### PR DESCRIPTION
As I explained here
https://github.com/tinkerbell/sandbox/pull/66#issuecomment-803009169 the
current OSIE on master broke how tink-worker gets installed in sandbox.

For a series of bad habits, the PR got merged even if e2e tests are
broken leaving sandbox/master to a not working state

This commit reverts OSIE back to a fully operational version