### PR TITLE
Update Terraform to 0.14 in shell.nix

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -14,5 +14,5 @@ in
 with pkgs;
 
 mkShell {
-  buildInputs = [ go nodePackages.prettier shellcheck shfmt terraform gpgme packer vagrant ];
+  buildInputs = [ go nodePackages.prettier shellcheck shfmt terraform_0_14 gpgme packer vagrant ];
 }


### PR DESCRIPTION
## Description

This change causes Nix to pull in Terraform v0.14 rather than v0.12 when users run `nix-shell`

## Why is this needed

Without this change I get this error on both Mac and NixOS:
```
[nix-shell:~/sandbox/deploy/terraform]$ terraform init --upgrade

Warning: Provider source not supported in Terraform v0.12

  on main.tf line 4, in terraform:
   4:     metal = {
   5:       source  = "equinix/metal"
   6:       version = "1.0.0"
   7:     }

A source was declared for provider metal. Terraform v0.12 does not support the
provider source attribute. It will be ignored.

(and 2 more similar warnings elsewhere)


Error: Unsupported Terraform Core version

This configuration does not support Terraform version 0.12.30. To proceed,
either choose another supported Terraform version or update the root module's
version constraint. Version constraints are normally set for good reason, so
updating the constraint may lead to other errors or unexpected behavior.
```

## How Has This Been Tested?

I used this on both a Mac and a NixOS machine using `nix-shell`

## How are existing users impacted? What migration steps/scripts do we need?

Running `nix-shell` on existing checkouts will now pull down a newer version of Terraform.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade