### PR TITLE
Reconfigure the registry to proxy quay.io/tinkerbell-actions

### DIFF
--- a/deploy/registry/Dockerfile
+++ b/deploy/registry/Dockerfile
@@ -4,4 +4,5 @@ ARG REGISTRY_USERNAME
 ARG REGISTRY_PASSWORD
 RUN mkdir -p /certs /auth
 RUN htpasswd -Bbn ${REGISTRY_USERNAME} ${REGISTRY_PASSWORD} > /auth/htpasswd
+ADD config.yml /etc/docker/registry/config.yml
 EXPOSE 443

--- a/deploy/registry/config.yml
+++ b/deploy/registry/config.yml
@@ -1,0 +1,22 @@
+version: 0.1
+proxy:
+  remoteurl: https://quay.io/tinkerbell-actions
+log:
+  accesslog:
+    disabled: true
+  fields:
+    service: registry
+storage:
+  cache:
+    blobdescriptor: inmemory
+  filesystem:
+    rootdirectory: /var/lib/registry
+http:
+  addr: :5000
+  headers:
+    X-Content-Type-Options: [nosniff]
+health:
+  storagedriver:
+    enabled: true
+    interval: 10s
+    threshold: 3


### PR DESCRIPTION
We need a way to simplify pull from `quay.io/tinkerbell-actions`, the
location for the reusable actions we release.

https://artifacthub.io/packages/search?kind=4

All the images are proxies via an internal registry. This commit
configures it to look at the images hosted in
`quay.io/tinkerbell-actions` when there is not one in the internal
registry and it proxies.

For example:

    $ docker pull 192.168.1.1/tinkerbell-actions/rootio:v1.0.0

    v1.0.0: Pulling from tinkerbell-actions/rootio
    b5b0f03f0cb8: Pull complete
    48742f086697: Pull complete
    06d27b65800a: Pull complete
    3281556401c6: Pull complete
    b94e835dc9fd: Pull complete
    Digest: sha256:ec9855556388a690cad2535cf813f69cffa6df24476aedb16b3cdfc0d809492c
    Status: Downloaded newer image for 192.168.1.1/tinkerbell-actions/rootio:v1.0.0
    192.168.1.1/tinkerbell-actions/rootio:v1.0.0
