### PR TITLE
Add jq to the nix-shell environment

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -14,5 +14,5 @@ in
 with pkgs;
 
 mkShell {
-  buildInputs = [ go nodePackages.prettier shellcheck shfmt terraform_0_14 gpgme packer vagrant ];
+  buildInputs = [ go nodePackages.prettier jq shellcheck shfmt terraform_0_14 gpgme packer vagrant ];
 }


### PR DESCRIPTION
Signed-off-by: Nahum Shalman <nshalman@equinix.com>

## Description

Add `jq` to the nix-shell environment

## Why is this needed

There are bits of documentation that use the sandbox and reference using `jq` from the command line.
This makes them work nicely.

## How Has This Been Tested?
On NixOS running `nix-shell` now has `jq` in the PATH.

## How are existing users impacted? What migration steps/scripts do we need?

N/A

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
