### PR TITLE
Fix setup.sh to work when .nat_interface doesn't exist

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -111,6 +111,7 @@ setup_networking() (
 		echo "$ERR tinkerbell network interface configuration failed"
 	fi
 
+	NAT_INTERFACE=""
 	if [ -r .nat_interface ]; then
 		NAT_INTERFACE=$(cat .nat_interface)
 	fi


### PR DESCRIPTION
## Description

This is a follow-up to #76 which introduced a failure:
```
provisioner: ./setup.sh: line 117: NAT_INTERFACE: unbound variable
```

## Why is this needed

Unbreak `setup.sh` when used by Vagrant

Fixes #77 

## How Has This Been Tested?

I used the following simple test case. It works now that the variable is declared first, but still breaks as reported without the fix.
```bash
#!/bin/bash
set -eu
NAT_INTERFACE=""
if [ -r .nat_interface ]; then
	NAT_INTERFACE=$(cat .nat_interface)
fi
if [ -n "$NAT_INTERFACE" ] && ip addr show "$NAT_INTERFACE" &>/dev/null; then
	echo "$NAT_INTERFACE"
fi
```

## How are existing users impacted? What migration steps/scripts do we need?

Vagrant users are currently broken as reported in the community Slack.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
