### PR TITLE
Fix empty docker-compose in basebox

### DIFF
--- a/deploy/vagrant/basebox/ubuntu1804/provision.sh
+++ b/deploy/vagrant/basebox/ubuntu1804/provision.sh
@@ -30,13 +30,17 @@ setup_docker() (
 		;
 )
 
+# from https://docs.docker.com/compose/install/
 setup_docker_compose() (
-	# from https://docs.docker.com/compose/install/
-	sudo curl -L \
-		"https://github.com/docker/compose/releases/download/1.26.0/docker-compose-$(uname -s)-$(uname -m)" \
-		-o /usr/local/bin/docker-compose
-
-	sudo chmod +x /usr/local/bin/docker-compose
+	local name url
+	name=docker-compose-$(uname -s)-$(uname -m)
+	url=https://github.com/docker/compose/releases/download/1.26.0/$name
+	curl -fsSLO "$url"
+	curl -fsSLO "$url.sha256"
+	sha256sum -c <"$name.sha256"
+	rm -f "$name.sha256"
+	chmod +x "$name"
+	sudo mv "$name" /usr/local/bin/docker-compose
 )
 
 main() (
@@ -50,3 +54,4 @@ main() (
 )
 
 main
+sync # do not remove!

--- a/deploy/vagrant/basebox/ubuntu1804/provision.sh
+++ b/deploy/vagrant/basebox/ubuntu1804/provision.sh
@@ -9,7 +9,8 @@ setup_docker() (
 		ca-certificates \
 		curl \
 		gnupg-agent \
-		software-properties-common
+		software-properties-common \
+		;
 
 	curl -fsSL https://download.docker.com/linux/ubuntu/gpg |
 		sudo apt-key add -
@@ -22,7 +23,11 @@ setup_docker() (
 	sudo add-apt-repository "$repo"
 
 	sudo apt-get update
-	sudo apt-get install -y docker-ce docker-ce-cli containerd.io
+	sudo apt-get install -y \
+		containerd.io \
+		docker-ce \
+		docker-ce-cli \
+		;
 )
 
 setup_docker_compose() (

--- a/deploy/vagrant/scripts/tinkerbell.sh
+++ b/deploy/vagrant/scripts/tinkerbell.sh
@@ -51,6 +51,9 @@ main() (
 
 	secure_certs
 	configure_vagrant_user
+
+	set +x # don't want the stderr output from xtrace messing with the post-setup-message
+	[[ -f /tmp/post-setup-message ]] && cat /tmp/post-setup-message
 )
 
 main

--- a/deploy/vagrant/scripts/tinkerbell.sh
+++ b/deploy/vagrant/scripts/tinkerbell.sh
@@ -34,7 +34,7 @@ setup_nat() (
 main() (
 	export DEBIAN_FRONTEND=noninteractive
 
-	if [ ! -f ./.env ]; then
+	if ! [[ -f ./.env ]]; then
 		./generate-env.sh eth1 >.env
 	fi
 

--- a/deploy/vagrant/scripts/tinkerbell.sh
+++ b/deploy/vagrant/scripts/tinkerbell.sh
@@ -39,7 +39,7 @@ main() (
 	fi
 
 	# shellcheck disable=SC1091
-	. ./.env
+	source ./.env
 
 	make_certs_writable
 

--- a/generate-env.sh
+++ b/generate-env.sh
@@ -14,7 +14,7 @@ ERR="${RED:-}ERROR:${RESET:-}"
 source ./current_versions.sh
 
 err() (
-	if [ -z "${1:-}" ]; then
+	if [[ -z ${1:-} ]]; then
 		cat >&2
 	else
 		echo "$ERR " "$@" >&2
@@ -94,7 +94,7 @@ EOF
 )
 
 main() (
-	if [ -z "${1:-}" ]; then
+	if [[ -z ${1:-} ]]; then
 		err "Usage: $0 network-interface-name > .env"
 		exit 1
 	fi

--- a/generate-env.sh
+++ b/generate-env.sh
@@ -53,44 +53,45 @@ generate_env() (
 	tink_password=$(generate_password)
 	local registry_password
 	registry_password=$(generate_password)
-	cat <<EOF
-# Tinkerbell Stack version
 
-export OSIE_DOWNLOAD_LINK=${OSIE_DOWNLOAD_LINK}
-export TINKERBELL_TINK_SERVER_IMAGE=${TINKERBELL_TINK_SERVER_IMAGE}
-export TINKERBELL_TINK_CLI_IMAGE=${TINKERBELL_TINK_CLI_IMAGE}
-export TINKERBELL_TINK_BOOTS_IMAGE=${TINKERBELL_TINK_BOOTS_IMAGE}
-export TINKERBELL_TINK_HEGEL_IMAGE=${TINKERBELL_TINK_HEGEL_IMAGE}
-export TINKERBELL_TINK_WORKER_IMAGE=${TINKERBELL_TINK_WORKER_IMAGE}
+	cat <<-EOF
+		# Tinkerbell Stack version
 
-# Network interface for Tinkerbell's network
-export TINKERBELL_NETWORK_INTERFACE="$tink_interface"
+		export OSIE_DOWNLOAD_LINK=${OSIE_DOWNLOAD_LINK}
+		export TINKERBELL_TINK_SERVER_IMAGE=${TINKERBELL_TINK_SERVER_IMAGE}
+		export TINKERBELL_TINK_CLI_IMAGE=${TINKERBELL_TINK_CLI_IMAGE}
+		export TINKERBELL_TINK_BOOTS_IMAGE=${TINKERBELL_TINK_BOOTS_IMAGE}
+		export TINKERBELL_TINK_HEGEL_IMAGE=${TINKERBELL_TINK_HEGEL_IMAGE}
+		export TINKERBELL_TINK_WORKER_IMAGE=${TINKERBELL_TINK_WORKER_IMAGE}
 
-# Decide on a subnet for provisioning. Tinkerbell should "own" this
-# network space. Its subnet should be just large enough to be able
-# to provision your hardware.
-export TINKERBELL_CIDR=29
+		# Network interface for Tinkerbell's network
+		export TINKERBELL_NETWORK_INTERFACE="$tink_interface"
 
-# Host IP is used by provisioner to expose different services such as
-# tink, boots, etc.
-#
-# The host IP should the first IP in the range, and the Nginx IP
-# should be the second address.
-export TINKERBELL_HOST_IP=192.168.1.1
+		# Decide on a subnet for provisioning. Tinkerbell should "own" this
+		# network space. Its subnet should be just large enough to be able
+		# to provision your hardware.
+		export TINKERBELL_CIDR=29
 
-# Tink server username and password
-export TINKERBELL_TINK_USERNAME=admin
-export TINKERBELL_TINK_PASSWORD="$tink_password"
+		# Host IP is used by provisioner to expose different services such as
+		# tink, boots, etc.
+		#
+		# The host IP should the first IP in the range, and the Nginx IP
+		# should be the second address.
+		export TINKERBELL_HOST_IP=192.168.1.1
 
-# Docker Registry's username and password
-export TINKERBELL_REGISTRY_USERNAME=admin
-export TINKERBELL_REGISTRY_PASSWORD="$registry_password"
+		# Tink server username and password
+		export TINKERBELL_TINK_USERNAME=admin
+		export TINKERBELL_TINK_PASSWORD="$tink_password"
 
-# Legacy options, to be deleted:
-export FACILITY=onprem
-export ROLLBAR_TOKEN=ignored
-export ROLLBAR_DISABLE=1
-EOF
+		# Docker Registry's username and password
+		export TINKERBELL_REGISTRY_USERNAME=admin
+		export TINKERBELL_REGISTRY_PASSWORD="$registry_password"
+
+		# Legacy options, to be deleted:
+		export FACILITY=onprem
+		export ROLLBAR_TOKEN=ignored
+		export ROLLBAR_DISABLE=1
+	EOF
 )
 
 main() (

--- a/setup.sh
+++ b/setup.sh
@@ -503,7 +503,7 @@ do_setup() (
 	setup_docker_registry
 
 	echo "$INFO tinkerbell stack setup completed successfully on $lsb_dist server"
-	whats_next
+	whats_next | tee /tmp/post-setup-message
 )
 
 # wrapped up in a function so that we have some protection against only getting

--- a/setup.sh
+++ b/setup.sh
@@ -427,13 +427,15 @@ command_exists() (
 )
 
 check_command() (
-	if command_exists "$1"; then
-		echo "$BLANK Found prerequisite: $1"
-		return 0
-	else
-		echo "$ERR Prerequisite command not installed: $1"
+	if ! command_exists "$1"; then
+		echo "$ERR Prerequisite executable command not found: $1"
 		return 1
 	fi
+	if ! [[ -s "$(which "$1")" ]]; then
+		echo "$ERR Prerequisite command is an empty file: $1"
+	fi
+	echo "$BLANK Found prerequisite: $1"
+	return 0
 )
 
 check_prerequisites() (

--- a/setup.sh
+++ b/setup.sh
@@ -479,7 +479,7 @@ check_prerequisites() (
 
 whats_next() (
 	echo "$NEXT  1. Enter /vagrant/deploy and run: source ../.env; docker-compose up -d"
-	echo "$BLANK 2. Try executing your fist workflow."
+	echo "$BLANK 2. Try executing your first workflow."
 	echo "$BLANK    Follow the steps described in https://tinkerbell.org/examples/hello-world/ to say 'Hello World!' with a workflow."
 )
 

--- a/setup.sh
+++ b/setup.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # stops the execution if a command or pipeline has an error
-set -eu
+set -euxo pipefail
 
 # Tinkerbell stack Linux setup script
 #

--- a/setup.sh
+++ b/setup.sh
@@ -38,7 +38,7 @@ NEXT="${GREEN:-}NEXT:${RESET:-}"
 get_distribution() (
 	local lsb_dist=""
 	# Every system that we officially support has /etc/os-release
-	if [ -r /etc/os-release ]; then
+	if [[ -r /etc/os-release ]]; then
 		# shellcheck disable=SC1091
 		lsb_dist="$(. /etc/os-release && echo "$ID")"
 	fi
@@ -50,7 +50,7 @@ get_distribution() (
 get_distro_version() (
 	local lsb_version="0"
 	# Every system that we officially support has /etc/os-release
-	if [ -r /etc/os-release ]; then
+	if [[ -r /etc/os-release ]]; then
 		# shellcheck disable=SC1091
 		lsb_version="$(. /etc/os-release && echo "$VERSION_ID")"
 	fi
@@ -112,10 +112,10 @@ setup_networking() (
 	fi
 
 	NAT_INTERFACE=""
-	if [ -r .nat_interface ]; then
+	if [[ -r .nat_interface ]]; then
 		NAT_INTERFACE=$(cat .nat_interface)
 	fi
-	if [ -n "$NAT_INTERFACE" ] && ip addr show "$NAT_INTERFACE" &>/dev/null; then
+	if [[ -n $NAT_INTERFACE ]] && ip addr show "$NAT_INTERFACE" &>/dev/null; then
 		# TODO(nshalman) the terraform code would just run these commands as-is once
 		# but it would be nice to make these more persistent based on OS
 		iptables -A FORWARD -i "$TINKERBELL_NETWORK_INTERFACE" -o "$NAT_INTERFACE" -j ACCEPT
@@ -135,10 +135,10 @@ setup_networking_manually() (
 
 setup_network_forwarding() (
 	# enable IP forwarding for docker
-	if [ "$(sysctl -n net.ipv4.ip_forward)" != "1" ]; then
-		if [ -d /etc/sysctl.d ]; then
+	if (($(sysctl -n net.ipv4.ip_forward) != 1)); then
+		if [[ -d /etc/sysctl.d ]]; then
 			echo "net.ipv4.ip_forward=1" >/etc/sysctl.d/99-tinkerbell.conf
-		elif [ -f /etc/sysctl.conf ]; then
+		elif [[ -f /etc/sysctl.conf ]]; then
 			echo "net.ipv4.ip_forward=1" >>/etc/sysctl.conf
 		fi
 
@@ -171,7 +171,7 @@ setup_networking_netplan() (
 )
 
 setup_networking_ubuntu_legacy() (
-	if [ ! -f /etc/network/interfaces ]; then
+	if ! [[ -f /etc/network/interfaces ]]; then
 		echo "$ERR file /etc/network/interfaces not found"
 		exit 1
 	fi
@@ -224,7 +224,7 @@ EOF
 
 	local cfgfile="/etc/sysconfig/network-scripts/ifcfg-$TINKERBELL_NETWORK_INTERFACE"
 
-	if [ -f "$cfgfile" ]; then
+	if [[ -f $cfgfile ]]; then
 		echo "$ERR network config already exists: $cfgfile"
 		echo "$BLANK Please update it to match this configuration:"
 		echo "$content"
@@ -245,12 +245,12 @@ setup_osie() (
 
 	local osie_current=$STATEDIR/webroot/misc/osie/current
 	local tink_workflow=$STATEDIR/webroot/workflow/
-	if [ ! -d "$osie_current" ] || [ ! -d "$tink_workflow" ]; then
+	if [[ ! -d $osie_current ]] || [[ ! -d $tink_workflow ]]; then
 		mkdir -p "$osie_current"
 		mkdir -p "$tink_workflow"
 		pushd "$SCRATCH"
 
-		if [ -z "${TB_OSIE_TAR:-}" ]; then
+		if [[ -z ${TB_OSIE_TAR:-} ]]; then
 			curl "${OSIE_DOWNLOAD_LINK}" -o ./osie.tar.gz
 			tar -zxf osie.tar.gz
 		else
@@ -305,7 +305,7 @@ check_container_status() (
 		--filter "event=health_status" \
 		--format '{{.Status}}')
 
-	if [ "$status" != "health_status: healthy" ]; then
+	if [[ $status != "health_status: healthy" ]]; then
 		echo "$ERR $container_name is not healthy. status: $status"
 		exit 1
 	fi
@@ -314,7 +314,7 @@ check_container_status() (
 generate_certificates() (
 	mkdir -p "$STATEDIR/certs"
 
-	if [ ! -f "$STATEDIR/certs/ca.json" ]; then
+	if ! [[ -f "$STATEDIR/certs/ca.json" ]]; then
 		jq \
 			'.
 			 | .names[0].L = $facility
@@ -325,7 +325,7 @@ generate_certificates() (
 			>"$STATEDIR/certs/ca.json"
 	fi
 
-	if [ ! -f "$STATEDIR/certs/server-csr.json" ]; then
+	if ! [[ -f "$STATEDIR/certs/server-csr.json" ]]; then
 		jq \
 			'.
 			| .hosts += [ $ip, "tinkerbell.\($facility).packet.net" ]
@@ -353,7 +353,7 @@ generate_certificates() (
 
 	# update host to trust registry certificate
 	if ! cmp --quiet "$STATEDIR/certs/ca.pem" "$certs_dir/tinkerbell.crt"; then
-		if [ ! -d "$certs_dir/tinkerbell.crt" ]; then
+		if ! [[ -d "$certs_dir/" ]]; then
 			# The user will be told to create the directory
 			# in the next block, if copying the certs there
 			# fails.
@@ -363,7 +363,7 @@ generate_certificates() (
 			echo "$ERR please copy $STATEDIR/certs/ca.pem to $certs_dir/tinkerbell.crt"
 			echo "$BLANK and run $0 again:"
 
-			if [ ! -d "$certs_dir" ]; then
+			if ! [[ -d $certs_dir ]]; then
 				echo "sudo mkdir -p '$certs_dir'"
 			fi
 			echo "sudo cp '$STATEDIR/certs/ca.pem' '$certs_dir/tinkerbell.crt'"
@@ -406,7 +406,7 @@ bootstrap_docker_registry() (
 
 setup_docker_registry() (
 	local registry_images="$STATEDIR/registry"
-	if [ ! -d "$registry_images" ]; then
+	if ! [[ -d $registry_images ]]; then
 		mkdir -p "$registry_images"
 	fi
 	start_registry
@@ -469,7 +469,7 @@ check_prerequisites() (
 		;;
 	esac
 
-	if [ $failed -eq 1 ]; then
+	if ((failed == 1)); then
 		echo "$ERR Prerequisites not met. Please install the missing commands and re-run $0."
 		exit 1
 	fi
@@ -489,7 +489,7 @@ do_setup() (
 	echo "$INFO starting tinkerbell stack setup"
 	check_prerequisites "$lsb_dist" "$lsb_version"
 
-	if [ ! -f "$ENV_FILE" ]; then
+	if ! [[ -f $ENV_FILE ]]; then
 		echo "$ERR Run './generate-env.sh network-interface > \"$ENV_FILE\"' before continuing."
 		exit 1
 	fi

--- a/setup.sh
+++ b/setup.sh
@@ -347,8 +347,8 @@ generate_certificates() (
 	local certs_dir="/etc/docker/certs.d/$TINKERBELL_HOST_IP"
 
 	# copy public key to NGINX for workers
-	if ! cmp --quiet "$STATEDIR"/certs/ca.pem "$STATEDIR/webroot/workflow/ca.pem"; then
-		cp "$STATEDIR"/certs/ca.pem "$STATEDIR/webroot/workflow/ca.pem"
+	if ! cmp --quiet "$STATEDIR/certs/ca.pem" "$STATEDIR/webroot/workflow/ca.pem"; then
+		cp "$STATEDIR/certs/ca.pem" "$STATEDIR/webroot/workflow/ca.pem"
 	fi
 
 	# update host to trust registry certificate


### PR DESCRIPTION
## Description

Ensures docker-compose is correctly downloaded.
Also adds some better debuggability to setup.sh and the vagrant provision script.
A bunch of misc clean ups following the boy scout rule (leave things better than you found them)

## Why is this needed

Fixes: #59 

## How Has This Been Tested?

`vagrant up provisioner` now works

## How are existing users impacted? What migration steps/scripts do we need?

Fixes a bug where the vagrant sandbox wasn't working.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
