### PR TITLE
deploy: Bump libvirt vagrant box version to 0.2.0

### DIFF
--- a/deploy/vagrant/Vagrantfile
+++ b/deploy/vagrant/Vagrantfile
@@ -26,7 +26,7 @@ Vagrant.configure('2') do |config|
 
   config.vm.define :provisioner do |provisioner|
     provisioner.vm.box = "tinkerbelloss/sandbox-ubuntu1804"
-    provisioner.vm.box_version = "0.1.0"
+    provisioner.vm.box_version = "0.2.0"
     provisioner.vm.hostname = 'provisioner'
     provisioner.vm.synced_folder './../../', '/vagrant'
     provisioner.vm.provision :shell,


### PR DESCRIPTION
## Description

Upgrade libvirt box version used in vagrant setup

## Why is this needed

Vagrant will continue to use the buggy v0.1.0 vagrant box until this is merged.
