### PR TITLE
tls Dockerfile: Move from alpine base

### DIFF
--- a/deploy/tls/Dockerfile
+++ b/deploy/tls/Dockerfile
@@ -1,7 +1,8 @@
-FROM alpine:3.11
+FROM registry.fedoraproject.org/fedora:34
 ENTRYPOINT [ "/entrypoint.sh" ]
 
-RUN apk add --no-cache --update --upgrade ca-certificates postgresql-client
-RUN apk add --no-cache --update --upgrade --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing cfssl
+RUN dnf install --setopt=tsflags=nodocs -y \
+        postgresql \
+        golang-github-cloudflare-cfssl
 
 COPY . .

--- a/deploy/tls/entrypoint.sh
+++ b/deploy/tls/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 # set -o errexit -o nounset -o pipefail
 

--- a/deploy/tls/gencerts.sh
+++ b/deploy/tls/gencerts.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 set -eux
 


### PR DESCRIPTION
## Description

This commit changes the `deploy/tls` Dockerfile to move from `alpine`
based image to a `fedora` based image because The `cfssl` package was
removed from the `alpine` package repositories

## Why is this needed

Currently one cannot build image due to unavailability of the package.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
