### PR TITLE
Enable skipping of network in setup.sh

### DIFF
--- a/generate-env.sh
+++ b/generate-env.sh
@@ -70,14 +70,14 @@ generate_env() (
 		# Decide on a subnet for provisioning. Tinkerbell should "own" this
 		# network space. Its subnet should be just large enough to be able
 		# to provision your hardware.
-		export TINKERBELL_CIDR=29
+		export TINKERBELL_CIDR=${TINKERBELL_CIDR:-"29"}
 
 		# Host IP is used by provisioner to expose different services such as
 		# tink, boots, etc.
 		#
 		# The host IP should the first IP in the range, and the Nginx IP
 		# should be the second address.
-		export TINKERBELL_HOST_IP=192.168.1.1
+		export TINKERBELL_HOST_IP=${TINKERBELL_HOST_IP:-"192.168.1.1"}
 
 		# Tink server username and password
 		export TINKERBELL_TINK_USERNAME=admin
@@ -86,6 +86,10 @@ generate_env() (
 		# Docker Registry's username and password
 		export TINKERBELL_REGISTRY_USERNAME=admin
 		export TINKERBELL_REGISTRY_PASSWORD="$registry_password"
+
+		# Tink cli options
+		export TINKERBELL_GRPC_AUTHORITY=${TINKERBELL_HOST_IP:-"192.168.1.1"}:42113
+		export TINKERBELL_CERT_URL=http://${TINKERBELL_HOST_IP:-"192.168.1.1"}:42114/cert
 
 		# Legacy options, to be deleted:
 		export FACILITY=onprem

--- a/setup.sh
+++ b/setup.sh
@@ -478,7 +478,7 @@ check_prerequisites() (
 )
 
 whats_next() (
-	echo "$NEXT  1. Enter /vagrant/deploy and run: source ../.env; docker-compose up -d"
+	echo "$NEXT  1. Enter /deploy and run: source ../.env; docker-compose up -d"
 	echo "$BLANK 2. Try executing your first workflow."
 	echo "$BLANK    Follow the steps described in https://tinkerbell.org/examples/hello-world/ to say 'Hello World!' with a workflow."
 )
@@ -499,7 +499,9 @@ do_setup() (
 	# shellcheck disable=SC1090
 	source "$ENV_FILE"
 
-	setup_networking "$lsb_dist" "$lsb_version"
+	if [[ -z $TINKERBELL_SKIP_NETWORKING ]]; then
+		setup_networking "$lsb_dist" "$lsb_version"
+	fi
 	setup_osie
 	generate_certificates
 	setup_docker_registry


### PR DESCRIPTION
## Description

* Enable skipping of network in `setup.sh`
* Fixed path to deploy dir in log message
* Allow `TINKERBELL_CIDR` and `TINKERBELL_HOST_IP` to be overridable
* Set environment variables for tink cli in .env

## Why is this needed

* If I'm using bare metal, I don't need any network setup.
* The log message was wrong
* Its handy to not have to hack `.env` file after its generated and just set `TINKERBELL_CIDR` and `TINKERBELL_HOST_IP` before running `generate-env.sh`
* Its handy to have the tink CLI env vars if you have the tink cli installed

Fixes: #87

## How Has This Been Tested?
Ran changes locally

## How are existing users impacted? What migration steps/scripts do we need?
N/A

## Checklist:

I'll update the bare metal docs in a follow up PR calling out the escape hatch