### PR TITLE
added `TINKERBELL_SKIP_NETWORKING` to `./generate_env.sh`

### DIFF
--- a/generate-env.sh
+++ b/generate-env.sh
@@ -64,6 +64,9 @@ generate_env() (
 		export TINKERBELL_TINK_HEGEL_IMAGE=${TINKERBELL_TINK_HEGEL_IMAGE}
 		export TINKERBELL_TINK_WORKER_IMAGE=${TINKERBELL_TINK_WORKER_IMAGE}
 
+		# Populate the quotes with anything to make it "true"
+		export TINKERBELL_SKIP_NETWORKING=""
+		
 		# Network interface for Tinkerbell's network
 		export TINKERBELL_NETWORK_INTERFACE="$tink_interface"
 


### PR DESCRIPTION
## Description
<!--- Please describe what this PR is going to change -->
The allows `vagrant up provisioner` to complete.

## Why is this needed
<!--- Link to issue you have raised -->
Without this change, the provisioner VM fails to complete.

Fixes: #91 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Executing `vagrant up provisioner` with the variable as an empty string:
```
[[TRUNCATED]]
    provisioner: ++ export TINKERBELL_SKIP_NETWORKING=
    provisioner: ++ TINKERBELL_SKIP_NETWORKING=
    provisioner: + make_certs_writable
[[TRUNCATED]]
    provisioner: ++ export TINKERBELL_SKIP_NETWORKING=
    provisioner: ++ TINKERBELL_SKIP_NETWORKING=
    provisioner: + [[ -z '' ]]
    provisioner: + setup_networking ubuntu 18.04
[[TRUNCATED]]
```
Removed the `.env` file and populate the variable string in the `./generate-env.sh` and rebuilt:
```
[[TRUNCATED]
    provisioner: ++ export TINKERBELL_SKIP_NETWORKING=true
    provisioner: ++ TINKERBELL_SKIP_NETWORKING=true
[[TRUNCATED]
    provisioner: + [[ -z true ]]
    # IT WAS SKIPPED
    provisioner: + setup_osie
[[TRUNCATED]
```
This failed with running in Vagrant as expected but provides the skip behavior desired.

**Note:** I am not able to test this on bare-metal for which the option was originally created.

## How are existing users impacted? What migration steps/scripts do we need?
<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->
Existing users are likely not impacted unless the `.env` was removed and recreated after #88 was merged. I was pondering whether or not the `.generate_env.sh` file should remove and recreate the `.env` file on each execution.

## Checklist:
I have:

- [ No ] updated the documentation and/or roadmap (if required)<br>However, the new option appears to need to be added to the ['On Bare Metal with Docker'](https://docs.tinkerbell.org/setup/on-bare-metal-with-docker/) section of the documentation.
- [ No ] added unit or e2e tests<br>I honestly don't know enough Go to contribute a test for Vagrant completion.
- [ No ] provided instructions on how to upgrade<br>There's nothing to upgrade beyond a `git pull`.
