### PR TITLE
Use rsync for vagrant-libvirt sync_folder:

### DIFF
--- a/deploy/vagrant/Vagrantfile
+++ b/deploy/vagrant/Vagrantfile
@@ -47,7 +47,7 @@ Vagrant.configure("2") do |config|
     end
 
     provisioner.vm.provider "libvirt" do |l, override|
-      override.vm.synced_folder '../', '/vagrant', type: "nfs", nfs_version: 4, "nfs_udp": false, mount_options: ["rw", "vers=4", "tcp"]
+      override.vm.synced_folder '../', '/vagrant', type: "rsync"
       # vagrant plugin install vagrant-docker-compose
       override.vm.provision :docker_compose,
         compose_version: "1.29.1",


### PR DESCRIPTION
## Description

The NFS type for synced_folder requires nfsd to be installed and running on a machine for vagrant up to be successful. 
nfs was used so that folders were r/w bidirectionally.
I don't really think there is a need for this bidirectional functionality.
Moving to rsync should make this work more universally.

## Why is this needed

Issue https://github.com/tinkerbell/sandbox/issues/97 reported.
Moving away from nfs for vagrant libvirt synced_folders should work more universally.

Fixes: #97

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [x] added unit or e2e tests
- [x] provided instructions on how to upgrade
