### PR TITLE
Update handling of Hook for new re-release:

### DIFF
--- a/deploy/compose/.env
+++ b/deploy/compose/.env
@@ -1,5 +1,5 @@
 #OSIE_DOWNLOAD_URL="https://tinkerbell-oss.s3.amazonaws.com/osie-uploads/osie-1790-23d78ea47f794d0e5c934b604579c26e5fce97f5.tar.gz"
-OSIE_DOWNLOAD_URL="https://github.com/tinkerbell/hook/releases/download/5.10.57/hook-x86_64.tar.gz"
+OSIE_DOWNLOAD_URL="https://github.com/tinkerbell/hook/releases/download/5.10.57/hook_x86_64.tar.gz"
 TINKERBELL_USE_HOOK="true"
 TINK_CLI_IMAGE="quay.io/tinkerbell/tink-cli:sha-8ea8a0e5"
 TINK_SERVER_IMAGE="quay.io/tinkerbell/tink:sha-8ea8a0e5"

--- a/deploy/compose/osie/lastmile.sh
+++ b/deploy/compose/osie/lastmile.sh
@@ -17,7 +17,7 @@ osie_extract() {
 	local source_dir="$1"
 	local dest_dir="$2"
 	local filename="$3"
-	tar -zxvf "${source_dir}"/"${filename}".tar.gz -C "${dest_dir}" --strip-components 1
+	tar -zxvf "${source_dir}"/"${filename}".tar.gz -C "${dest_dir}"
 }
 
 # osie_move_helper_scripts moves workflow helper scripts to the workflow directory
@@ -62,13 +62,12 @@ main() {
 	fi
 
 	if [ "${use_hook}" == "true" ]; then
-		if [ ! -f "${source_dir}"/hook-x86_64-kernel ] && [ ! -f "${source_dir}"/hook-x86_64-initrd.img ]; then
+		if [ ! -f "${source_dir}"/vmlinuz-x86_64 ] && [ ! -f "${source_dir}"/initramfs-x86_64 ]; then
 			echo "extracting hook..."
 			osie_extract "${extract_dir}" "${source_dir}" "${filename}"
 		else
 			echo "hook files already exist, not extracting"
 		fi
-		hook_rename_files "${source_dir}"/hook-x86_64-kernel "${source_dir}"/hook-x86_64-initrd.img "${source_dir}"
 	else
 		if [ ! -f "${source_dir}"/workflow-helper.sh ] && [ ! -f "${source_dir}"/workflow-helper-rc ]; then
 			echo "extracting osie..."


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->

Hook re-released its existing version 5.10.57 with changes to its file name and structure inside its tarball.
This breaks the way Hook is downloaded and extracted.
This gets the docker-compose back up and running.

## Why is this needed

<!--- Link to issue you have raised -->

Sandbox is currently broken. The existing Hook download location does not exist anymore.

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
