### PR TITLE
Add support for the aarch64 Hook

### DIFF
--- a/deploy/compose/.env
+++ b/deploy/compose/.env
@@ -1,5 +1,5 @@
-#OSIE_DOWNLOAD_URL="https://tinkerbell-oss.s3.amazonaws.com/osie-uploads/osie-1790-23d78ea47f794d0e5c934b604579c26e5fce97f5.tar.gz"
-OSIE_DOWNLOAD_URL="https://github.com/tinkerbell/hook/releases/download/5.10.57/hook_x86_64.tar.gz"
+#OSIE_DOWNLOAD_URLS="https://tinkerbell-oss.s3.amazonaws.com/osie-uploads/osie-1790-23d78ea47f794d0e5c934b604579c26e5fce97f5.tar.gz"
+OSIE_DOWNLOAD_URLS="https://github.com/tinkerbell/hook/releases/download/5.10.57/hook_x86_64.tar.gz,https://github.com/tinkerbell/hook/releases/download/5.10.57/hook_aarch64.tar.gz"
 TINKERBELL_USE_HOOK="true"
 TINK_CLI_IMAGE="quay.io/tinkerbell/tink-cli:sha-8ea8a0e5"
 TINK_SERVER_IMAGE="quay.io/tinkerbell/tink:sha-8ea8a0e5"

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -31,7 +31,7 @@ services:
     entrypoint: /scripts/lastmile.sh
     command:
       [
-        "${OSIE_DOWNLOAD_URL}",
+        "${OSIE_DOWNLOAD_URLS}",
         "/source",
         "/source",
         "/destination",

--- a/deploy/compose/osie/lastmile.sh
+++ b/deploy/compose/osie/lastmile.sh
@@ -60,19 +60,17 @@ process_osie_file() {
 	if [ ! -f "${extract_dir}"/"${filename}".tar.gz ]; then
 		echo "downloading osie..."
 		osie_download "${url}" "${extract_dir}" "${filename}"
+		if [ "${use_hook}" == "true" ]; then
+			echo "extracting hook..."
+			hook_extract "${extract_dir}" "${source_dir}" "${filename}"
+		else
+			echo "extracting osie..."
+			osie_extract "${extract_dir}" "${source_dir}" "${filename}"
+			osie_move_helper_scripts "${source_dir}" "${dest_dir}"
+		fi
 	else
 		echo "osie already downloaded"
 	fi
-
-	if [ "${use_hook}" == "true" ]; then
-		echo "extracting hook..."
-		hook_extract "${extract_dir}" "${source_dir}" "${filename}"
-	else
-		echo "extracting osie..."
-		osie_extract "${extract_dir}" "${source_dir}" "${filename}"
-		osie_move_helper_scripts "${source_dir}" "${dest_dir}"
-	fi
-
 }
 
 # main runs the functions in order to download, extract, and move helper scripts

--- a/deploy/compose/osie/lastmile.sh
+++ b/deploy/compose/osie/lastmile.sh
@@ -5,6 +5,7 @@
 set -xo pipefail
 
 # osie_download from url and save it to directory
+# requires a filename so that any subsequent calls can check if the file has been downloaded
 osie_download() {
 	local url="$1"
 	local directory="$2"
@@ -47,20 +48,14 @@ hook_rename_files() {
 	mv "${src_initrd}" "${dest_dir}/initramfs-x86_64"
 }
 
-# main runs the functions in order to download, extract, and move helper scripts
-main() {
+# process_osie_files processes the OSIE files and moves them to the correct location
+process_osie_file() {
 	local url="$1"
-	local extract_dir="$2"
-	local source_dir="$3"
-	local dest_dir="$4"
-	local use_hook="$5"
-
-	local filename
-	if [ "${use_hook}" == "true" ]; then
-		filename="osie-hook"
-	else
-		filename="osie"
-	fi
+	local filename="$2"
+	local extract_dir="$3"
+	local source_dir="$4"
+	local dest_dir="$5"
+	local use_hook="$6"
 
 	if [ ! -f "${extract_dir}"/"${filename}".tar.gz ]; then
 		echo "downloading osie..."
@@ -70,21 +65,37 @@ main() {
 	fi
 
 	if [ "${use_hook}" == "true" ]; then
-		if [ ! -f "${source_dir}"/vmlinuz-x86_64 ] && [ ! -f "${source_dir}"/initramfs-x86_64 ]; then
-			echo "extracting hook..."
-			hook_extract "${extract_dir}" "${source_dir}" "${filename}"
-		else
-			echo "hook files already exist, not extracting"
-		fi
+		echo "extracting hook..."
+		hook_extract "${extract_dir}" "${source_dir}" "${filename}"
 	else
-		if [ ! -f "${source_dir}"/workflow-helper.sh ] && [ ! -f "${source_dir}"/workflow-helper-rc ]; then
-			echo "extracting osie..."
-			osie_extract "${extract_dir}" "${source_dir}" "${filename}"
-		else
-			echo "osie files already exist, not extracting"
-		fi
+		echo "extracting osie..."
+		osie_extract "${extract_dir}" "${source_dir}" "${filename}"
 		osie_move_helper_scripts "${source_dir}" "${dest_dir}"
 	fi
+
+}
+
+# main runs the functions in order to download, extract, and move helper scripts
+main() {
+	local urls="$1"
+	local extract_dir="$2"
+	local source_dir="$3"
+	local dest_dir="$4"
+	local use_hook="$5"
+
+	# create an array using the urls variable, delimited by commas (IFS=,)
+	# store the array in the variable "urls_array"
+	IFS=, read -ra urls_array <<<"${urls}"
+	for index in "${!urls_array[@]}"; do
+		echo "$index: ${urls_array[$index]}"
+		local filename
+		if [ "${use_hook}" == "true" ]; then
+			filename="osie-hook-${index}"
+		else
+			filename="osie-${index}"
+		fi
+		process_osie_file "${urls_array[$index]}" "${filename}" "${extract_dir}" "${source_dir}" "${dest_dir}" "${use_hook}"
+	done
 }
 
 main "$1" "$2" "$3" "$4" "$5"


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->

Hook repo just recently released support for aarch64.
This change adds support for downloading these files.


## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
