### PR TITLE
Expose hegel ports in docker compose

### DIFF
--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -294,7 +294,9 @@ services:
     depends_on:
       tink-server:
         condition: service_healthy
-
+    ports:
+      - 50060:50060/tcp
+      - 50061:50061/tcp
 volumes:
   postgres_data:
   certs:


### PR DESCRIPTION
## Description

Expose hegel ports in docker-compose.yml

## Why is this needed

This allows hegel to be reached by the machines being provisioned.

## How Has This Been Tested?

Tested manually when updating cluster-api-provider-tinkerbell documentation to use latest sandbox vs the v0.5.0 tag.

## How are existing users impacted? What migration steps/scripts do we need?

Should not have any impact on existing users, since this was not working previously.

