### PR TITLE
Automatically generate the release notes using the github api

### DIFF
--- a/.github/workflows/tags.yaml
+++ b/.github/workflows/tags.yaml
@@ -9,6 +9,16 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+      - name: Generate Release Notes
+        run: |
+          release_notes=$(gh api repos/{owner}/{repo}/releases/generate-notes -F tag_name=${{ github.ref }} --jq .body)
+          echo 'RELEASE_NOTES<<EOF' >> $GITHUB_ENV
+          echo "${release_notes}" >> $GITHUB_ENV
+          echo 'EOF' >> $GITHUB_ENV
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
@@ -17,5 +27,6 @@ jobs:
         with:
           tag_name: ${{ github.ref }}
           release_name: Release ${{ github.ref }}
+          body: ${{ env.RELEASE_NOTES }}
           draft: false
           prerelease: false


### PR DESCRIPTION
## Description

Automatically generate release notes using the newly released GitHub API for doing so: https://github.blog/2021-10-04-beta-github-releases-improving-release-experience/

## Why is this needed

Avoids having to manually create the release notes, or not having release notes