### PR TITLE
Remove the CA certificate from bundle

### DIFF
--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -217,7 +217,7 @@ services:
       REGISTRY_AUTH: htpasswd
       REGISTRY_AUTH_HTPASSWD_REALM: Registry Realm
       REGISTRY_AUTH_HTPASSWD_PATH: /auth/.htpasswd
-      REGISTRY_HTTP_TLS_CERTIFICATE: /certs/${FACILITY:-onprem}/bundle.pem
+      REGISTRY_HTTP_TLS_CERTIFICATE: /certs/${FACILITY:-onprem}/server-crt.pem
       REGISTRY_HTTP_TLS_KEY: /certs/${FACILITY:-onprem}/server-key.pem
       REGISTRY_HTTP_ADDR: $TINKERBELL_HOST_IP:443
     volumes:

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -59,20 +59,6 @@ services:
       registry:
         condition: service_healthy
 
-  # registry ca.crt download
-  registry-ca-crt-download:
-    image: alpine
-    entrypoint: wget
-    working_dir: /code
-    command: ["http://$TINKERBELL_HOST_IP:42114/cert", "-O", "ca.pem"]
-    volumes:
-      - ${REPO_TOP_LEVEL:-.}/state/webroot/workflow:/code
-    depends_on:
-      tink-server:
-        condition: service_healthy
-      db:
-        condition: service_healthy
-
   # Create hardware, template, and workflow records in tink-server
   create-tink-records:
     image: ${TINK_CLI_IMAGE}

--- a/deploy/compose/tls/ca-csr.json
+++ b/deploy/compose/tls/ca-csr.json
@@ -1,0 +1,12 @@
+{
+  "CN": "Tinkerbell CA",
+  "key": {
+    "algo": "rsa",
+    "size": 2048
+  },
+  "names": [
+    {
+      "L": "@FACILITY@"
+    }
+  ]
+}

--- a/deploy/compose/tls/ca-csr.json
+++ b/deploy/compose/tls/ca-csr.json
@@ -1,8 +1,8 @@
 {
   "CN": "Tinkerbell CA",
   "key": {
-    "algo": "rsa",
-    "size": 2048
+    "algo": "ecdsa",
+    "size": 256
   },
   "names": [
     {

--- a/deploy/compose/tls/csr.json
+++ b/deploy/compose/tls/csr.json
@@ -1,5 +1,5 @@
 {
-  "CN": "tinkerbell",
+  "CN": "Tinkerbell",
   "hosts": [
     "tinkerbell.registry",
     "tinkerbell.tinkerbell",

--- a/deploy/compose/tls/csr.json
+++ b/deploy/compose/tls/csr.json
@@ -10,8 +10,8 @@
     "localhost"
   ],
   "key": {
-    "algo": "rsa",
-    "size": 2048
+    "algo": "ecdsa",
+    "size": 256
   },
   "names": [
     {

--- a/deploy/compose/tls/generate.sh
+++ b/deploy/compose/tls/generate.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 # This script handles the generation of the TLS certificates.
-# The output is 2 files:
-# 1. /certs/${FACILITY:-onprem}/server-key.pem (TLS private key)
-# 2. /certs/${FACILITY:-onprem}/bundle.pem (TLS public certificate)
+# The output is 4 files:
+# 1. /certs/${FACILITY:-onprem}/ca-crt.pem (CA TLS public certificate)
+# 2. /certs/${FACILITY:-onprem}/server-crt.pem (server TLS certificate)
+# 3. /certs/${FACILITY:-onprem}/server-key.pem (server TLS private key)
+# 4. /certs/${FACILITY:-onprem}/bundle.pem (server TLS certificate; backward compat)
 
 set -xo pipefail
 
@@ -18,32 +20,40 @@ cleanup() {
 	rm -rf ca-key.pem ca.csr ca.pem server.csr server.pem
 }
 
-# gen will generate the key and bundle
+# gen will generate the key and certificate
 gen() {
-	local bundle_destination="$1"
-	local key_destination="$2"
+	local ca_crt_destination="$1"
+	local server_crt_destination="$2"
+	local server_key_destination="$3"
 	cfssl gencert -initca /code/tls/csr.json | cfssljson -bare ca -
 	cfssl gencert -config /code/tls/ca-config.json -ca ca.pem -ca-key ca-key.pem -profile server /code/tls/csr.json | cfssljson -bare server
-	cat server.pem ca.pem >"${bundle_destination}"
-	mv server-key.pem "${key_destination}"
+	mv ca.pem "${ca_crt_destination}"
+	mv server.pem "${server_crt_destination}"
+	mv server-key.pem "${server_key_destination}"
 }
 
 # main orchestrates the process
 main() {
 	local sans_ip="$1"
 	local csr_file="/code/tls/csr.json"
-	local bundle_file="/certs/${FACILITY:-onprem}/bundle.pem"
+	local ca_crt_file="/certs/${FACILITY:-onprem}/ca-crt.pem"
+	local server_crt_file="/certs/${FACILITY:-onprem}/server-crt.pem"
 	local server_key_file="/certs/${FACILITY:-onprem}/server-key.pem"
+	# NB this is required for backward compat.
+	# TODO once the other think-* services use server-crt.pem this should
+	#      be removed.
+	local bundle_crt_file="/certs/${FACILITY:-onprem}/bundle.pem"
 
 	if ! grep -q "${sans_ip}" "${csr_file}"; then
 		update_csr "${sans_ip}" "${csr_file}"
 	else
 		echo "IP ${sans_ip} already in ${csr_file}"
 	fi
-	if [ ! -f "${bundle_file}" ] && [ ! -f "${server_key_file}" ]; then
-		gen "${bundle_file}" "${server_key_file}"
+	if [ ! -f "${ca_crt_file}" ] && [ ! -f "${server_crt_file}" ] && [ ! -f "${server_key_file}" ]; then
+		gen "${ca_crt_file}" "${server_crt_file}" "${server_key_file}"
+		cp "${server_crt_file}" "${bundle_crt_file}"
 	else
-		echo "Files [${bundle_file}, ${server_key_file}] already exist"
+		echo "Files [${ca_crt_file}, ${server_crt_file}, ${server_key_file}] already exist"
 	fi
 	cleanup
 }

--- a/deploy/compose/tls/generate.sh
+++ b/deploy/compose/tls/generate.sh
@@ -25,7 +25,7 @@ gen() {
 	local ca_crt_destination="$1"
 	local server_crt_destination="$2"
 	local server_key_destination="$3"
-	cfssl gencert -initca /code/tls/csr.json | cfssljson -bare ca -
+	cfssl gencert -initca /code/tls/ca-csr.json | cfssljson -bare ca -
 	cfssl gencert -config /code/tls/ca-config.json -ca ca.pem -ca-key ca-key.pem -profile server /code/tls/csr.json | cfssljson -bare server
 	mv ca.pem "${ca_crt_destination}"
 	mv server.pem "${server_crt_destination}"

--- a/deploy/compose/tls/generate.sh
+++ b/deploy/compose/tls/generate.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 # This script handles the generation of the TLS certificates.
-# The output is 4 files:
+# This generates the files:
 # 1. /certs/${FACILITY:-onprem}/ca-crt.pem (CA TLS public certificate)
 # 2. /certs/${FACILITY:-onprem}/server-crt.pem (server TLS certificate)
 # 3. /certs/${FACILITY:-onprem}/server-key.pem (server TLS private key)
 # 4. /certs/${FACILITY:-onprem}/bundle.pem (server TLS certificate; backward compat)
+# 5. /code/state/webroot/workflow/ca.pem (CA TLS public certificate)
 
-set -xo pipefail
+set -euxo pipefail
 
 # update_csr will add the sans_ip, as a valid host domain in the csr
 update_csr() {
@@ -36,6 +37,7 @@ gen() {
 main() {
 	local sans_ip="$1"
 	local csr_file="/code/tls/csr.json"
+	local ca_crt_workflow_file="/code/state/webroot/workflow/ca.pem"
 	local ca_crt_file="/certs/${FACILITY:-onprem}/ca-crt.pem"
 	local server_crt_file="/certs/${FACILITY:-onprem}/server-crt.pem"
 	local server_key_file="/certs/${FACILITY:-onprem}/server-key.pem"
@@ -54,6 +56,11 @@ main() {
 		cp "${server_crt_file}" "${bundle_crt_file}"
 	else
 		echo "Files [${ca_crt_file}, ${server_crt_file}, ${server_key_file}] already exist"
+	fi
+	if [ ! -f "${ca_crt_workflow_file}" ]; then
+		cp "${ca_crt_file}" "${ca_crt_workflow_file}"
+	else
+		echo "File ${ca_crt_workflow_file} already exist"
 	fi
 	cleanup
 }

--- a/deploy/compose/tls/trust.sh
+++ b/deploy/compose/tls/trust.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -euxo pipefail
+
+TINKERBELL_HOST_IP="$1"
+
+if [ -d /vagrant/compose ]; then
+	cd /vagrant/compose
+fi
+
+# trust the tinkerbell CA.
+docker-compose exec -T registry cat /certs/onprem/ca-crt.pem >/usr/local/share/ca-certificates/tinkerbell.crt
+update-ca-certificates
+systemctl restart docker
+
+# login into the docker registry.
+docker login "$TINKERBELL_HOST_IP" --username admin --password-stdin <<<'Admin1234'
+if id -u vagrant >/dev/null 2>&1; then
+	su vagrant -c "docker login \"$TINKERBELL_HOST_IP\" --username admin --password-stdin" <<<'Admin1234'
+fi
+
+# ensure everything is up after docker restart.
+docker-compose up --detach

--- a/deploy/terraform/main.tf
+++ b/deploy/terraform/main.tf
@@ -102,7 +102,8 @@ resource "null_resource" "setup" {
   provisioner "remote-exec" {
     inline = [
       "cd /root && tar zxvf /root/compose.tar.gz -C /root/sandbox",
-      "cd /root/sandbox/compose && TINKERBELL_CLIENT_MAC=${metal_device.tink_worker.ports[1].mac} TINKERBELL_TEMPLATE_MANIFEST=/manifests/template/ubuntu-equinix-metal.yaml TINKERBELL_HARDWARE_MANIFEST=/manifests/hardware/hardware-equinix-metal.json docker-compose up -d"
+      "cd /root/sandbox/compose && TINKERBELL_CLIENT_MAC=${metal_device.tink_worker.ports[1].mac} TINKERBELL_TEMPLATE_MANIFEST=/manifests/template/ubuntu-equinix-metal.yaml TINKERBELL_HARDWARE_MANIFEST=/manifests/hardware/hardware-equinix-metal.json docker-compose up -d",
+      "cd /root/sandbox/compose && bash tls/trust.sh ${metal_device.tink_provisioner.network[0].address}",
     ]
   }
 }

--- a/deploy/vagrant/Vagrantfile
+++ b/deploy/vagrant/Vagrantfile
@@ -15,6 +15,26 @@ unless Vagrant.has_plugin?("vagrant-docker-compose")
   exit
 end
 
+def provision_provisioner(config, provider_name)
+  if provider_name == 'virtualbox'
+    manifest_suffix = ''
+  else
+    manifest_suffix = "-#{provider_name}"
+  end
+  config.vm.provision :docker_compose,
+    compose_version: "1.29.2",
+    yml: "/vagrant/compose/docker-compose.yml",
+    run: "always",
+    env: {
+      "TINKERBELL_HOST_IP": PROVISIONER_IP,
+      "TINKERBELL_CLIENT_IP": MACHINE1_IP,
+      "REPO_TOP_LEVEL": "/vagrant/compose",
+      "TINKERBELL_HARDWARE_MANIFEST": "/manifests/hardware/hardware#{manifest_suffix}.json",
+      "TINKERBELL_TEMPLATE_MANIFEST": "/manifests/template/ubuntu#{manifest_suffix}.yaml"
+    }
+  config.vm.provision "shell", name: "Trust the Tinkerbell CA", path: "../compose/tls/trust.sh", args: [PROVISIONER_IP]
+end
+
 Vagrant.configure("2") do |config|
   config.vm.provider :libvirt do |libvirt|
     libvirt.qemu_use_session = false
@@ -36,34 +56,14 @@ Vagrant.configure("2") do |config|
       v.memory = 2048
       v.cpus = 2
       override.vm.synced_folder '../', '/vagrant'
-      # vagrant plugin install vagrant-docker-compose
-      override.vm.provision :docker_compose,
-        compose_version: "1.29.1",
-        yml: "/vagrant/compose/docker-compose.yml",
-        run:"always",
-        env: {
-          "TINKERBELL_HOST_IP": PROVISIONER_IP,
-          "TINKERBELL_CLIENT_IP": MACHINE1_IP,
-          "REPO_TOP_LEVEL": "/vagrant/compose",
-          "TINKERBELL_HARDWARE_MANIFEST": "/manifests/hardware/hardware.json",
-          "TINKERBELL_TEMPLATE_MANIFEST": "/manifests/template/ubuntu.yaml"
-        }
+      provision_provisioner(override, 'virtualbox')
     end
 
     provisioner.vm.provider "libvirt" do |l, override|
-      override.vm.synced_folder '../', '/vagrant', type: "rsync"
-      # vagrant plugin install vagrant-docker-compose
-      override.vm.provision :docker_compose,
-        compose_version: "1.29.1",
-        yml: "/vagrant/compose/docker-compose.yml",
-        run:"always",
-        env: {
-          "TINKERBELL_HOST_IP": PROVISIONER_IP,
-          "TINKERBELL_CLIENT_IP": MACHINE1_IP,
-          "REPO_TOP_LEVEL": "/vagrant/compose",
-          "TINKERBELL_HARDWARE_MANIFEST": "/manifests/hardware/hardware-libvirt.json",
-          "TINKERBELL_TEMPLATE_MANIFEST": "/manifests/template/ubuntu-libvirt.yaml"
-        }
+      l.memory = 2048
+      l.cpus = 2
+      override.vm.synced_folder '../', '/vagrant', type: 'rsync'
+      provision_provisioner(override, 'libvirt')
     end
   end
 


### PR DESCRIPTION
## Description

See https://github.com/tinkerbell/sandbox/issues/105

I also took the opportunity to:

1. use a different csr for the tinkerbell ca (this allows us to clearly identify the ca and server certificates)
2. switch from rsa to ecdsa (its equally safer and its generally faster)
3. modify tls-gen to also copy the ca certificate to the workflow directory (this simplifies the compose file)
4. Configure the vagrant environment to trust the tinkerbell CA. 
5. Configure the vagrant environment root and vagrant accounts to automatically login into the registry. 

## Why is this needed

See https://github.com/tinkerbell/sandbox/issues/105

Fixes: #105

## How Has This Been Tested?

Tested locally by starting Tinkerbell with compose and vagrant.

## How are existing users impacted? What migration steps/scripts do we need?

Should not be impacted.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
