### PR TITLE
Use init with registry since it forks

### DIFF
--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -202,6 +202,7 @@ services:
 
   registry:
     image: registry:2.7.1
+    init: true
     restart: unless-stopped
     network_mode: host
     healthcheck:


### PR DESCRIPTION
Avoids many zombie processes left over

## Description

Without this change, many zombie processes get left over in the registry container. Eventually these will run the system out of PIDs

## Why is this needed

System will have issues if too many zombie processes are left over

Fixes: #

## How Has This Been Tested?
Monitored number of processes via `docker stats`

## How are existing users impacted? What migration steps/scripts do we need?

Bug fix

## Checklist:

I have:

- [N/A] updated the documentation and/or roadmap (if required)
- [N/A] added unit or e2e tests
- [N/A] provided instructions on how to upgrade
