### PR TITLE
Pin version of skopeo

### DIFF
--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -44,7 +44,7 @@ services:
 
   # Uploads images in /registry/registry_images.txt to the local registry
   images-to-local-registry:
-    image: quay.io/containers/skopeo:latest
+    image: quay.io/containers/skopeo:v1.4.1
     entrypoint: /registry/upload.sh
     command:
       [


### PR DESCRIPTION
Ran into issues with latest and the others are pinned

## Description

Pin the version of skopeo

## Why is this needed

I ran into issues with the latest skopeo. Pinning it avoided it, and the others seem to be pinned (at least registry and bash), so let's pin this too.

Fixes: #

## How Has This Been Tested?

Yep, tested in a VM

## How are existing users impacted? What migration steps/scripts do we need?

Should avoid a potential issue

## Checklist:

I have:

- [N/A] updated the documentation and/or roadmap (if required)
- [N/A] added unit or e2e tests
- [N/A] provided instructions on how to upgrade
