### PR TITLE
Re-add persistent registry storage

### DIFF
--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -230,6 +230,7 @@ services:
     volumes:
       - certs:/certs/${FACILITY:-onprem}:ro
       - auth:/auth:rw
+      - registry_data:/var/lib/registry:rw
     depends_on:
       tls-gen:
         condition: service_completed_successfully
@@ -323,3 +324,4 @@ volumes:
   postgres_data:
   certs:
   auth:
+  registry_data:


### PR DESCRIPTION
## Description

Re-adds persistent registry storage to docker compose configuration

## Why is this needed

Previous releases of the sandbox (<= v0.5) had persistent storage for the registry, this fixes the regression where registry storage was no longer persistent with v0.6 release and HEAD

## How Has This Been Tested?
- Bring up a clean environment, verify provisioning works
- Push an additional image to the registry that wasn't configured in /registry/registry_images.txt
- Do a docker compose down on the provisioner
- Do a docker compose up on the provisioner
- Verify that all images still exist in the registry

## How are existing users impacted? What migration steps/scripts do we need?

This should not impact existing users, since it fixes the regression and issues users would encounter where registry storage is wiped when the registry container is re-created.

