### PR TITLE
Fix TLS gen() func to use updated csr file:

### DIFF
--- a/deploy/compose/generate-tls-certs/generate.sh
+++ b/deploy/compose/generate-tls-certs/generate.sh
@@ -26,8 +26,9 @@ gen() {
 	local ca_crt_destination="$1"
 	local server_crt_destination="$2"
 	local server_key_destination="$3"
+	local csr_file="$4"
 	cfssl gencert -initca /app/ca-csr.json | cfssljson -bare ca -
-	cfssl gencert -config /app/ca-config.json -ca ca.pem -ca-key ca-key.pem -profile server /app/csr.json | cfssljson -bare server
+	cfssl gencert -config /app/ca-config.json -ca ca.pem -ca-key ca-key.pem -profile server "${csr_file}" | cfssljson -bare server
 	mv ca.pem "${ca_crt_destination}"
 	mv server.pem "${server_crt_destination}"
 	mv server-key.pem "${server_key_destination}"
@@ -52,7 +53,7 @@ main() {
 		echo "IP ${sans_ip} already in ${csr_file}"
 	fi
 	if [ ! -f "${ca_crt_file}" ] && [ ! -f "${server_crt_file}" ] && [ ! -f "${server_key_file}" ]; then
-		gen "${ca_crt_file}" "${server_crt_file}" "${server_key_file}"
+		gen "${ca_crt_file}" "${server_crt_file}" "${server_key_file}" "${csr_file}"
 		cp "${server_crt_file}" "${bundle_crt_file}"
 	else
 		echo "Files [${ca_crt_file}, ${server_crt_file}, ${server_key_file}] already exist"


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
This fixes a regression in the docker-compose where the `TINKERBELL_HOST_IP` in the .env file wasn't showing up as a sans ip in the TLS certificate. This caused all TLS communication with the Tink server to fail with an error like:

`x509: certificate is valid for 192.168.56.4, 127.0.0.1, not 192.168.2.150`

This was happening because the updated csr.json file was not being used to generate the TLS certs. In this line [here](https://github.com/tinkerbell/sandbox/blob/467e0b54da44ba6657842268a75ad3b66cc35b8a/deploy/compose/generate-tls-certs/generate.sh#L16), the csr.json is updated and written to this location [here](https://github.com/tinkerbell/sandbox/blob/467e0b54da44ba6657842268a75ad3b66cc35b8a/deploy/compose/generate-tls-certs/generate.sh#L39). But this line [here](https://github.com/tinkerbell/sandbox/blob/467e0b54da44ba6657842268a75ad3b66cc35b8a/deploy/compose/generate-tls-certs/generate.sh#L30), where the TLS certs are generated, was not using this updated location. It was using this hardcoded location: `/app/csr.json`.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #127 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->

The certs docker volume will need to be deleted and then re-run `docker-compose up -d`


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
