### PR TITLE
[WIP] Update sandbox for latest changes

### DIFF
--- a/deploy/compose/.env
+++ b/deploy/compose/.env
@@ -2,8 +2,8 @@ OSIE_DOWNLOAD_URLS=https://github.com/tinkerbell/hook/releases/download/5.10.57/
 
 BOOTS_SERVER_IMAGE=quay.io/tinkerbell/boots:sha-d15a9bfd
 HEGEL_SERVER_IMAGE=quay.io/tinkerbell/hegel:sha-e570bc4f
-TINK_CLI_IMAGE=quay.io/tinkerbell/tink-cli:sha-d3512cb4
-TINK_SERVER_IMAGE=quay.io/tinkerbell/tink:sha-d3512cb4
+TINK_CLI_IMAGE=quay.io/tinkerbell/tink-cli:sha-08a2e129
+TINK_SERVER_IMAGE=quay.io/tinkerbell/tink:sha-08a2e129
 
 TINKERBELL_HARDWARE_MANIFEST=/manifests/hardware/hardware.json
 TINKERBELL_TEMPLATE_MANIFEST=/manifests/template/ubuntu.yaml

--- a/deploy/compose/.env
+++ b/deploy/compose/.env
@@ -1,9 +1,9 @@
 OSIE_DOWNLOAD_URLS=https://github.com/tinkerbell/hook/releases/download/5.10.57/hook_x86_64.tar.gz,https://github.com/tinkerbell/hook/releases/download/5.10.57/hook_aarch64.tar.gz
 
-BOOTS_SERVER_IMAGE=quay.io/tinkerbell/boots:sha-36f12f81
-HEGEL_SERVER_IMAGE=quay.io/tinkerbell/hegel:sha-89cb9dc8
-TINK_CLI_IMAGE=quay.io/tinkerbell/tink-cli:sha-e053ada6
-TINK_SERVER_IMAGE=quay.io/tinkerbell/tink:sha-3743d31e
+BOOTS_SERVER_IMAGE=quay.io/tinkerbell/boots:sha-d15a9bfd
+HEGEL_SERVER_IMAGE=quay.io/tinkerbell/hegel:sha-e570bc4f
+TINK_CLI_IMAGE=quay.io/tinkerbell/tink-cli:sha-d3512cb4
+TINK_SERVER_IMAGE=quay.io/tinkerbell/tink:sha-d3512cb4
 
 TINKERBELL_HARDWARE_MANIFEST=/manifests/hardware/hardware.json
 TINKERBELL_TEMPLATE_MANIFEST=/manifests/template/ubuntu.yaml

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   ##### Actual services first #####
   boots:
     image: ${BOOTS_SERVER_IMAGE}
-    command: -dhcp-addr 0.0.0.0:67 -tftp-addr $TINKERBELL_HOST_IP:69 -http-addr $TINKERBELL_HOST_IP:80 -log-level DEBUG
+    command: -dhcp-addr 0.0.0.0:67 -ipxe-tftp-addr $TINKERBELL_HOST_IP:69 -http-addr $TINKERBELL_HOST_IP:80 -log-level DEBUG
     network_mode: host
     environment:
       API_AUTH_TOKEN: ${PACKET_API_AUTH_TOKEN:-ignored}

--- a/deploy/compose/sync-images-to-local-registry/registry_images.txt
+++ b/deploy/compose/sync-images-to-local-registry/registry_images.txt
@@ -1,6 +1,4 @@
-quay.io/tinkerbell/tink-worker:latest tinkerbell/tink-worker:latest
-quay.io/tinkerbell/tink-worker:latest tink-worker:latest
-quay.io/tinkerbell/tink-worker:latest tinkerbell/tink-worker:sha-5e1f0fd8
+quay.io/detiber/tink-worker:latest tink-worker:latest
 quay.io/tinkerbell-actions/image2disk:v1.0.0 image2disk:v1.0.0
 quay.io/tinkerbell-actions/cexec:v1.0.0 cexec:v1.0.0
 quay.io/tinkerbell-actions/writefile:v1.0.0 writefile:v1.0.0

--- a/deploy/compose/sync-images-to-local-registry/registry_images.txt
+++ b/deploy/compose/sync-images-to-local-registry/registry_images.txt
@@ -1,4 +1,4 @@
-quay.io/detiber/tink-worker:latest tink-worker:latest
+quay.io/tinkerbell/tink-worker:sha-08a2e129 tink-worker:latest
 quay.io/tinkerbell-actions/image2disk:v1.0.0 image2disk:v1.0.0
 quay.io/tinkerbell-actions/cexec:v1.0.0 cexec:v1.0.0
 quay.io/tinkerbell-actions/writefile:v1.0.0 writefile:v1.0.0


### PR DESCRIPTION
## Description

Update sandbox for latest Tinkerbell chagnes

## Why is this needed

The last sandbox release is getting quite a bit old at v0.6.0, with all the changes that have landed since then, it's about time for a v0.7.0 release

## How Has This Been Tested?

TODO

## How are existing users impacted? What migration steps/scripts do we need?

TODO

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade


## Blockers:

 - [x] https://github.com/tinkerbell/tink/pull/604
 - [ ] https://github.com/tinkerbell/tink/pull/603
 - [ ] https://github.com/tinkerbell/hegel/pull/80
 - [ ] Tagged semver release for boots
 - [ ] Tagged semver release for tink
 - [ ] Tagged semver release for hegel