### PR TITLE
Do not hardcode vagrant network details

### DIFF
--- a/deploy/vagrant/Vagrantfile
+++ b/deploy/vagrant/Vagrantfile
@@ -1,8 +1,10 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-PROVISIONER_IP = "192.168.56.4"
-MACHINE1_IP = "192.168.56.43"
+LIBVIRT_HOST_IP = ENV["LIBVIRT_HOST_IP"] || "192.168.56.1"
+PROVISIONER_IP = ENV["PROVISIONER_IP"] || "192.168.56.4"
+MACHINE1_IP = ENV["MACHINE1_IP"] || "192.168.56.43"
+MACHINE1_MAC = (ENV["MACHINE1_MAC"] || "08:00:27:9E:F5:3A").downcase
 
 Vagrant.configure("2") do |config|
   config.vm.provider :libvirt do |libvirt|
@@ -14,7 +16,7 @@ Vagrant.configure("2") do |config|
     provisioner.vm.synced_folder "../compose/", "/sandbox/compose/"
     provisioner.vm.network "private_network", ip: PROVISIONER_IP,
                                               libvirt__network_name: "tink_network",
-                                              libvirt__host_ip: "192.168.56.1",
+                                              libvirt__host_ip: LIBVIRT_HOST_IP,
                                               libvirt__netmask: "255.255.255.0",
                                               libvirt__dhcp_enabled: false,
                                               auto_config: false
@@ -31,7 +33,7 @@ Vagrant.configure("2") do |config|
       override.vm.synced_folder "../compose/", "/sandbox/compose/", type: "rsync"
     end
 
-    provisioner.vm.provision :shell, path: "setup.sh", args: [PROVISIONER_IP, MACHINE1_IP, "08:00:27:9e:f5:3a"]
+    provisioner.vm.provision :shell, path: "setup.sh", args: [PROVISIONER_IP, MACHINE1_IP, MACHINE1_MAC]
   end
 
   config.vm.define :machine1, autostart: false do |machine1|
@@ -39,7 +41,7 @@ Vagrant.configure("2") do |config|
     machine1.vm.boot_timeout = 10
     machine1.vm.synced_folder ".", "/vagrant", disabled: true
     machine1.vm.network :private_network, ip: MACHINE1_IP,
-                                          mac: "0800279EF53A",
+                                          mac: MACHINE1_MAC.gsub(/[:-]/, ""),
                                           adapter: 1,
                                           libvirt__network_name: "tink_network",
                                           libvirt__dhcp_enabled: false,

--- a/deploy/vagrant/Vagrantfile
+++ b/deploy/vagrant/Vagrantfile
@@ -31,7 +31,7 @@ Vagrant.configure("2") do |config|
       override.vm.synced_folder "../compose/", "/sandbox/compose/", type: "rsync"
     end
 
-    provisioner.vm.provision :shell, path: "setup.sh", args: [PROVISIONER_IP, MACHINE1_IP]
+    provisioner.vm.provision :shell, path: "setup.sh", args: [PROVISIONER_IP, MACHINE1_IP, "08:00:27:9e:f5:3a"]
   end
 
   config.vm.define :machine1, autostart: false do |machine1|

--- a/deploy/vagrant/setup.sh
+++ b/deploy/vagrant/setup.sh
@@ -39,12 +39,14 @@ setup_layer2_network() {
 setup_compose_env_overrides() {
 	local host_ip=$1
 	local worker_ip=$2
+	local worker_mac=$3
 	if lsblk | grep -q vda; then
 		sed -i 's|sda|vda|g' /sandbox/compose/create-tink-records/manifests/template/ubuntu.yaml
 	fi
 	readarray -t lines <<-EOF
 		TINKERBELL_HOST_IP="$host_ip"
 		TINKERBELL_CLIENT_IP="$worker_ip"
+		TINKERBELL_CLIENT_MAC="$worker_mac"
 	EOF
 	for line in "${lines[@]}"; do
 		grep -q "$line" /sandbox/compose/.env && continue
@@ -75,6 +77,7 @@ tweak_bash_interactive_settings() {
 main() {
 	local host_ip=$1
 	local worker_ip=$2
+	local worker_mac=$3
 
 	update_apt
 	install_docker
@@ -82,7 +85,7 @@ main() {
 
 	setup_layer2_network "$host_ip"
 
-	setup_compose_env_overrides "$host_ip" "$worker_ip"
+	setup_compose_env_overrides "$host_ip" "$worker_ip" "$worker_mac"
 	docker-compose -f /sandbox/compose/docker-compose.yml up -d
 
 	create_tink_helper_script

--- a/deploy/vagrant/setup.sh
+++ b/deploy/vagrant/setup.sh
@@ -30,21 +30,21 @@ update_apt() {
 }
 
 setup_layer2_network() {
-	host_addr=$1
-	ip addr show dev eth1 | grep -q "$host_addr" && return 0
-	ip addr add "$host_addr/24" dev eth1
+	local host_ip=$1
+	ip addr show dev eth1 | grep -q "$host_ip" && return 0
+	ip addr add "$host_ip/24" dev eth1
 	ip link set dev eth1 up
 }
 
 setup_compose_env_overrides() {
-	local host_addr=$1
-	local worker_addr=$2
+	local host_ip=$1
+	local worker_ip=$2
 	if lsblk | grep -q vda; then
 		sed -i 's|sda|vda|g' /sandbox/compose/create-tink-records/manifests/template/ubuntu.yaml
 	fi
 	readarray -t lines <<-EOF
-		TINKERBELL_HOST_IP="$host_addr"
-		TINKERBELL_CLIENT_IP="$worker_addr"
+		TINKERBELL_HOST_IP="$host_ip"
+		TINKERBELL_CLIENT_IP="$worker_ip"
 	EOF
 	for line in "${lines[@]}"; do
 		grep -q "$line" /sandbox/compose/.env && continue
@@ -73,16 +73,16 @@ tweak_bash_interactive_settings() {
 }
 
 main() {
-	local host_addr=$1
-	local worker_addr=$2
+	local host_ip=$1
+	local worker_ip=$2
 
 	update_apt
 	install_docker
 	install_docker_compose
 
-	setup_layer2_network "$host_addr"
+	setup_layer2_network "$host_ip"
 
-	setup_compose_env_overrides "$host_addr" "$worker_addr"
+	setup_compose_env_overrides "$host_ip" "$worker_ip"
 	docker-compose -f /sandbox/compose/docker-compose.yml up -d
 
 	create_tink_helper_script


### PR DESCRIPTION
## Description

Allows for overriding the default vagrant/libvirt network details.

## Why is this needed

Lets us use the vagrant and compose setup in a sort of hybrid mode with a real hw machine as machine1 instead of the VM. 

## How Has This Been Tested?

Ran `vagrant up` and verified defaults still work and overrides do in fact show up.

## How are existing users impacted? What migration steps/scripts do we need?

A way to test with real hardware while using the vagrant setup for the services.
