### PR TITLE
add helm chart to deploy Tinkerbell in K8S

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,35 +2,56 @@
 # BEGIN: lint-install ../sandbox
 # http://github.com/tinkerbell/lint-install
 
+HELM_VERSION ?= v3.9.0
 GOLINT_VERSION ?= v1.42.0
-
 SHELLCHECK_VERSION ?= v0.7.2
-LINT_OS := $(shell uname)
-LINT_ARCH := $(shell uname -m)
+
+OS := $(shell uname)
+ARCH := $(shell uname -m)
+LOWERCASE_OS  = $(shell echo $(OS) | tr '[:upper:]' '[:lower:]')
+
+HELM_ARCH := $(ARCH)
+ifeq ($(ARCH),x86_64)
+	HELM_ARCH=amd64
+endif
+
 LINT_ROOT := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
 # shellcheck and hadolint lack arm64 native binaries: rely on x86-64 emulation
-ifeq ($(LINT_OS),Darwin)
-	ifeq ($(LINT_ARCH),arm64)
-		LINT_ARCH=x86_64
+ifeq ($(OS),Darwin)
+	ifeq ($(ARCH),arm64)
+		ARCH=x86_64
 	endif
 endif
 
-LINT_LOWER_OS  = $(shell echo $(LINT_OS) | tr '[:upper:]' '[:lower:]')
 GOLINT_CONFIG:=$(LINT_ROOT)/.golangci.yml
 
-lint: out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)/shellcheck out/linters/golangci-lint-$(GOLINT_VERSION)-$(LINT_ARCH)
-	find . -name go.mod | xargs -n1 dirname | xargs -n1 -I{} sh -c "cd {} && $(LINT_ROOT)/out/linters/golangci-lint-$(GOLINT_VERSION)-$(LINT_ARCH) run -c $(GOLINT_CONFIG)"
-	out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)/shellcheck $(shell find . -name "*.sh")
+.PHONY: helm
+helm: out/helm/$(LOWERCASE_OS)-$(HELM_ARCH)
+	./out/helm/${LOWERCASE_OS}-${HELM_ARCH}/helm package helm-charts/tinkerbell 
 
-out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)/shellcheck:
+out/helm/$(LOWERCASE_OS)-$(HELM_ARCH):
+	mkdir -p out/helm
+	echo $(HELM_ARCH)
+	curl -sSfL https://get.helm.sh/helm-$(HELM_VERSION)-$(LOWERCASE_OS)-$(HELM_ARCH).tar.gz | tar -C out/helm -xzvf -
+
+lint: out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(ARCH)/shellcheck out/linters/golangci-lint-$(GOLINT_VERSION)-$(ARCH)
+	find . -name go.mod | xargs -n1 dirname | xargs -n1 -I{} sh -c "cd {} && $(LINT_ROOT)/out/linters/golangci-lint-$(GOLINT_VERSION)-$(ARCH) run -c $(GOLINT_CONFIG)"
+	out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(ARCH)/shellcheck $(shell find . -name "*.sh")
+
+out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(ARCH)/shellcheck:
 	mkdir -p out/linters
-	curl -sSfL https://github.com/koalaman/shellcheck/releases/download/$(SHELLCHECK_VERSION)/shellcheck-$(SHELLCHECK_VERSION).$(LINT_LOWER_OS).$(LINT_ARCH).tar.xz | tar -C out/linters -xJf -
-	mv out/linters/shellcheck-$(SHELLCHECK_VERSION) out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)
+	curl -sSfL https://github.com/koalaman/shellcheck/releases/download/$(SHELLCHECK_VERSION)/shellcheck-$(SHELLCHECK_VERSION).$(LOWERCASE_OS).$(ARCH).tar.xz | tar -C out/linters -xJf -
+	mv out/linters/shellcheck-$(SHELLCHECK_VERSION) out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(ARCH)
 
-out/linters/golangci-lint-$(GOLINT_VERSION)-$(LINT_ARCH):
+out/linters/golangci-lint-$(GOLINT_VERSION)-$(ARCH):
 	mkdir -p out/linters
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b out/linters $(GOLINT_VERSION)
-	mv out/linters/golangci-lint out/linters/golangci-lint-$(GOLINT_VERSION)-$(LINT_ARCH)
+	mv out/linters/golangci-lint out/linters/golangci-lint-$(GOLINT_VERSION)-$(ARCH)
 
 # END: lint-install ../sandbox
+
+.PHONY: clean
+clean: ## Clean up resources created by make targets
+	rm -rf ./out
+	rm tinkerbell-*.tgz

--- a/helm-charts/tinkerbell/Chart.yaml
+++ b/helm-charts/tinkerbell/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: tinkerbell
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/helm-charts/tinkerbell/templates/boots-deployment.yaml
+++ b/helm-charts/tinkerbell/templates/boots-deployment.yaml
@@ -1,0 +1,44 @@
+{{- if .Values.boots.deploy }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: {{ .Values.boots.name }}
+  name:  {{ .Values.boots.name }}
+  namespace: {{ .Values.namespace }}
+spec:
+  replicas: {{ .Values.boots.replicas }}
+  selector:
+    matchLabels:
+      app: {{ .Values.boots.name }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Values.boots.name }}
+    spec:
+      containers:
+        - image: {{ .Values.boots.image }}
+          imagePullPolicy: {{ .Values.boots.imagePullPolicy }}
+          {{- if .Values.boots.args }}
+          args: 
+          {{- range .Values.boots.args }}
+            - {{ . }}
+          {{- end }}
+          {{- end }}
+          env:
+            - name: "DATA_MODEL_VERSION"
+              value: "kubernetes"
+            {{- range $i, $env := .Values.boots.env }}
+            - name: {{ $env.name | quote }}
+              value: {{ $env.value | quote }}
+            {{- end }}
+          name: {{ .Values.boots.name }}
+          resources:
+            limits:
+              cpu: {{ .Values.boots.resources.limits.cpu }}
+              memory: {{ .Values.boots.resources.limits.memory }}
+            requests:
+              cpu: {{ .Values.boots.resources.requests.cpu }}
+              memory: {{ .Values.boots.resources.requests.memory }}
+      serviceAccountName: {{ .Values.boots.name }}
+{{- end }}

--- a/helm-charts/tinkerbell/templates/boots-role.yaml
+++ b/helm-charts/tinkerbell/templates/boots-role.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.boots.deploy }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Values.boots.roleName }}
+  namespace: {{ .Values.namespace }}
+rules:
+  - apiGroups:
+      - tinkerbell.org
+    resources:
+      - hardware
+      - hardware/status
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - tinkerbell.org
+    resources:
+      - workflows
+      - workflows/status
+    verbs:
+      - get
+      - list
+      - watch
+{{- end }}

--- a/helm-charts/tinkerbell/templates/boots-rolebinding.yaml
+++ b/helm-charts/tinkerbell/templates/boots-rolebinding.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.boots.deploy }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Values.boots.roleBindingName }}
+  namespace: {{ .Values.namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Values.boots.roleName }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.boots.name }}
+    namespace: {{ .Values.namespace }}
+{{- end }}

--- a/helm-charts/tinkerbell/templates/boots-service-account.yaml
+++ b/helm-charts/tinkerbell/templates/boots-service-account.yaml
@@ -1,0 +1,7 @@
+{{- if .Values.boots.deploy }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.boots.name }}
+  namespace: {{ .Values.namespace }}
+{{- end }}

--- a/helm-charts/tinkerbell/templates/hardware-crd.yaml
+++ b/helm-charts/tinkerbell/templates/hardware-crd.yaml
@@ -1,0 +1,383 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.8.0
+  creationTimestamp: null
+  labels:
+    clusterctl.cluster.x-k8s.io: ""
+    clusterctl.cluster.x-k8s.io/move: ""
+  name: hardware.tinkerbell.org
+spec:
+  group: tinkerbell.org
+  names:
+    categories:
+      - tinkerbell
+    kind: Hardware
+    listKind: HardwareList
+    plural: hardware
+    shortNames:
+      - hw
+    singular: hardware
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.state
+          name: State
+          type: string
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: Hardware is the Schema for the Hardware API.
+          properties:
+            apiVersion:
+              description:
+                "APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
+              type: string
+            kind:
+              description:
+                "Kind is a string value representing the REST resource this
+                object represents. Servers may infer this from the endpoint the client
+                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: HardwareSpec defines the desired state of Hardware.
+              properties:
+                bmcRef:
+                  description:
+                    BMCRef contains a relation to a BMC state management
+                    type in the same namespace as the Hardware. This may be used for
+                    BMC management by orchestrators.
+                  properties:
+                    apiGroup:
+                      description:
+                        APIGroup is the group for the resource being referenced.
+                        If APIGroup is not specified, the specified Kind must be in
+                        the core API group. For any other third-party types, APIGroup
+                        is required.
+                      type: string
+                    kind:
+                      description: Kind is the type of resource being referenced
+                      type: string
+                    name:
+                      description: Name is the name of resource being referenced
+                      type: string
+                  required:
+                    - kind
+                    - name
+                  type: object
+                disks:
+                  items:
+                    description: Disk represents a disk device for Tinkerbell Hardware.
+                    properties:
+                      device:
+                        type: string
+                    type: object
+                  type: array
+                interfaces:
+                  items:
+                    description:
+                      Interface represents a network interface configuration
+                      for Hardware.
+                    properties:
+                      dhcp:
+                        description: DHCP configuration.
+                        properties:
+                          arch:
+                            type: string
+                          hostname:
+                            type: string
+                          iface_name:
+                            type: string
+                          ip:
+                            description: IP configuration.
+                            properties:
+                              address:
+                                type: string
+                              family:
+                                format: int64
+                                type: integer
+                              gateway:
+                                type: string
+                              netmask:
+                                type: string
+                            type: object
+                          lease_time:
+                            format: int64
+                            type: integer
+                          mac:
+                            type: string
+                          name_servers:
+                            items:
+                              type: string
+                            type: array
+                          time_servers:
+                            items:
+                              type: string
+                            type: array
+                          uefi:
+                            type: boolean
+                        type: object
+                      netboot:
+                        description: Netboot configuration.
+                        properties:
+                          allowPXE:
+                            type: boolean
+                          allowWorkflow:
+                            type: boolean
+                          ipxe:
+                            description: IPXE configuration.
+                            properties:
+                              contents:
+                                type: string
+                              url:
+                                type: string
+                            type: object
+                          osie:
+                            description: OSIE configuration.
+                            properties:
+                              baseURL:
+                                type: string
+                              initrd:
+                                type: string
+                              kernel:
+                                type: string
+                            type: object
+                        type: object
+                    type: object
+                  type: array
+                metadata:
+                  properties:
+                    bonding_mode:
+                      format: int64
+                      type: integer
+                    custom:
+                      properties:
+                        preinstalled_operating_system_version:
+                          properties:
+                            distro:
+                              type: string
+                            image_tag:
+                              type: string
+                            os_slug:
+                              type: string
+                            slug:
+                              type: string
+                            version:
+                              type: string
+                          type: object
+                        private_subnets:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    facility:
+                      properties:
+                        facility_code:
+                          type: string
+                        plan_slug:
+                          type: string
+                        plan_version_slug:
+                          type: string
+                      type: object
+                    instance:
+                      properties:
+                        allow_pxe:
+                          type: boolean
+                        always_pxe:
+                          type: boolean
+                        crypted_root_password:
+                          type: string
+                        hostname:
+                          type: string
+                        id:
+                          type: string
+                        ips:
+                          items:
+                            properties:
+                              address:
+                                type: string
+                              family:
+                                format: int64
+                                type: integer
+                              gateway:
+                                type: string
+                              management:
+                                type: boolean
+                              netmask:
+                                type: string
+                              public:
+                                type: boolean
+                            type: object
+                          type: array
+                        ipxe_script_url:
+                          type: string
+                        network_ready:
+                          type: boolean
+                        operating_system:
+                          properties:
+                            distro:
+                              type: string
+                            image_tag:
+                              type: string
+                            os_slug:
+                              type: string
+                            slug:
+                              type: string
+                            version:
+                              type: string
+                          type: object
+                        rescue:
+                          type: boolean
+                        ssh_keys:
+                          items:
+                            type: string
+                          type: array
+                        state:
+                          type: string
+                        storage:
+                          properties:
+                            disks:
+                              items:
+                                properties:
+                                  device:
+                                    type: string
+                                  partitions:
+                                    items:
+                                      properties:
+                                        label:
+                                          type: string
+                                        number:
+                                          format: int64
+                                          type: integer
+                                        size:
+                                          format: int64
+                                          type: integer
+                                        start:
+                                          format: int64
+                                          type: integer
+                                        type_guid:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  wipe_table:
+                                    type: boolean
+                                type: object
+                              type: array
+                            filesystems:
+                              items:
+                                properties:
+                                  mount:
+                                    properties:
+                                      create:
+                                        properties:
+                                          force:
+                                            type: boolean
+                                          options:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      device:
+                                        type: string
+                                      files:
+                                        items:
+                                          properties:
+                                            contents:
+                                              type: string
+                                            gid:
+                                              format: int64
+                                              type: integer
+                                            mode:
+                                              format: int64
+                                              type: integer
+                                            path:
+                                              type: string
+                                            uid:
+                                              format: int64
+                                              type: integer
+                                          type: object
+                                        type: array
+                                      format:
+                                        type: string
+                                      point:
+                                        type: string
+                                    type: object
+                                type: object
+                              type: array
+                            raid:
+                              items:
+                                properties:
+                                  devices:
+                                    items:
+                                      type: string
+                                    type: array
+                                  level:
+                                    type: string
+                                  name:
+                                    type: string
+                                  spare:
+                                    format: int64
+                                    type: integer
+                                type: object
+                              type: array
+                          type: object
+                        tags:
+                          items:
+                            type: string
+                          type: array
+                        userdata:
+                          type: string
+                      type: object
+                    manufacturer:
+                      properties:
+                        id:
+                          type: string
+                        slug:
+                          type: string
+                      type: object
+                    state:
+                      type: string
+                  type: object
+                resources:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description:
+                    Resources represents known resources that are available
+                    on a machine. Resources may be used for scheduling by orchestrators.
+                  type: object
+                tinkVersion:
+                  format: int64
+                  type: integer
+                userData:
+                  description:
+                    UserData is the user data to configure in the hardware's
+                    metadata
+                  type: string
+              type: object
+            status:
+              description: HardwareStatus defines the observed state of Hardware.
+              properties:
+                state:
+                  description: HardwareState represents the hardware state.
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/helm-charts/tinkerbell/templates/hegel-deployment.yaml
+++ b/helm-charts/tinkerbell/templates/hegel-deployment.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.hegel.deploy }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: {{ .Values.hegel.name }}
+  name:  {{ .Values.hegel.name }}
+  namespace: {{ .Values.namespace }}
+spec:
+  replicas: {{ .Values.hegel.replicas }}
+  selector:
+    matchLabels:
+      app: {{ .Values.hegel.name }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Values.hegel.name }}
+    spec:
+      containers:
+        - args:
+          - --data-model=kubernetes
+          {{- range .Values.hegel.args }}
+          - {{ . }}
+          {{- end }}
+          image: {{ .Values.hegel.image }}
+          imagePullPolicy: {{ .Values.tinkController.imagePullPolicy }}
+          name: {{ .Values.hegel.name }}
+          {{- if .Values.hegel.port.hostPortEnabled }}
+          ports:
+            - containerPort: {{ .Values.hegel.port.hostPort }}
+              hostPort: {{ .Values.hegel.port.hostPort }}
+              name: http
+          {{- end }}
+          resources:
+            limits:
+              cpu: {{ .Values.hegel.resources.limits.cpu }}
+              memory: {{ .Values.hegel.resources.limits.memory }}
+            requests:
+              cpu: {{ .Values.hegel.resources.requests.cpu }}
+              memory: {{ .Values.hegel.resources.requests.memory }}
+      serviceAccountName: {{ .Values.hegel.name }}
+{{- end }}

--- a/helm-charts/tinkerbell/templates/hegel-role.yaml
+++ b/helm-charts/tinkerbell/templates/hegel-role.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.hegel.deploy }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Values.hegel.roleName }}
+  namespace: {{ .Values.namespace }}
+rules:
+  - apiGroups:
+      - tinkerbell.org
+    resources:
+      - hardware
+      - hardware/status
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - tinkerbell.org
+    resources:
+      - workflows
+      - workflows/status
+    verbs:
+      - get
+      - list
+      - watch
+{{- end }}

--- a/helm-charts/tinkerbell/templates/hegel-rolebinding.yaml
+++ b/helm-charts/tinkerbell/templates/hegel-rolebinding.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.hegel.deploy }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Values.hegel.roleBindingName }}
+  namespace: {{ .Values.namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .Values.hegel.roleName }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.hegel.name }}
+    namespace: {{ .Values.namespace }}
+{{- end }}

--- a/helm-charts/tinkerbell/templates/hegel-service-account.yaml
+++ b/helm-charts/tinkerbell/templates/hegel-service-account.yaml
@@ -1,0 +1,7 @@
+{{- if .Values.hegel.deploy }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.hegel.name }}
+  namespace: {{ .Values.namespace }}
+{{- end }}

--- a/helm-charts/tinkerbell/templates/namespace.yaml
+++ b/helm-charts/tinkerbell/templates/namespace.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.createNamespace }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: {{ .Values.namespace }}
+{{- end }}

--- a/helm-charts/tinkerbell/templates/template-crd.yaml
+++ b/helm-charts/tinkerbell/templates/template-crd.yaml
@@ -1,0 +1,70 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.8.0
+  creationTimestamp: null
+  labels:
+    clusterctl.cluster.x-k8s.io: ""
+    clusterctl.cluster.x-k8s.io/move: ""
+  name: templates.tinkerbell.org
+spec:
+  group: tinkerbell.org
+  names:
+    categories:
+      - tinkerbell
+    kind: Template
+    listKind: TemplateList
+    plural: templates
+    shortNames:
+      - tpl
+    singular: template
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.state
+          name: State
+          type: string
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: Template is the Schema for the Templates API.
+          properties:
+            apiVersion:
+              description:
+                "APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
+              type: string
+            kind:
+              description:
+                "Kind is a string value representing the REST resource this
+                object represents. Servers may infer this from the endpoint the client
+                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: TemplateSpec defines the desired state of Template.
+              properties:
+                data:
+                  type: string
+              type: object
+            status:
+              description: TemplateStatus defines the observed state of Template.
+              properties:
+                state:
+                  description: TemplateState represents the template state.
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/helm-charts/tinkerbell/templates/tink-controller-cluster-role-binding.yaml
+++ b/helm-charts/tinkerbell/templates/tink-controller-cluster-role-binding.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.tinkController.deploy }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name:  {{ .Values.tinkController.roleBindingName }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Values.tinkController.roleName }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.tinkController.name }}
+    namespace: {{ .Values.namespace }}
+{{- end }}

--- a/helm-charts/tinkerbell/templates/tink-controller-cluster-role.yaml
+++ b/helm-charts/tinkerbell/templates/tink-controller-cluster-role.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.tinkController.deploy }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Values.tinkController.roleName }}
+rules:
+  - apiGroups:
+      - tinkerbell.org
+    resources:
+      - hardware
+      - hardware/status
+    verbs:
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - tinkerbell.org
+    resources:
+      - templates
+      - templates/status
+    verbs:
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - tinkerbell.org
+    resources:
+      - workflows
+      - workflows/status
+    verbs:
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+{{- end }}

--- a/helm-charts/tinkerbell/templates/tink-controller-deployment.yaml
+++ b/helm-charts/tinkerbell/templates/tink-controller-deployment.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.tinkController.deploy }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: {{ .Values.tinkController.name }}
+  name: {{ .Values.tinkController.name }}
+  namespace: {{ .Values.namespace }}
+spec:
+  replicas: {{ .Values.tinkController.replicas }}
+  selector:
+    matchLabels:
+      app: {{ .Values.tinkController.name }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Values.tinkController.name }}
+    spec:
+      containers:
+        - image: {{ .Values.tinkController.image }}
+          imagePullPolicy: {{ .Values.tinkController.imagePullPolicy }}
+          {{- if .Values.tinkController.args }}
+          args: 
+          {{- range .Values.tinkController.args }}
+            - {{ . }}
+          {{- end }}
+          {{- end }}
+          name: {{ .Values.tinkController.name }}
+          resources:
+            limits:
+              cpu: {{ .Values.tinkController.resources.limits.cpu }}
+              memory: {{ .Values.tinkController.resources.limits.memory }}
+            requests:
+              cpu: {{ .Values.tinkController.resources.requests.cpu }}
+              memory: {{ .Values.tinkController.resources.requests.memory }}
+      serviceAccountName: {{ .Values.tinkController.name }}
+{{- end }}

--- a/helm-charts/tinkerbell/templates/tink-controller-service-account.yaml
+++ b/helm-charts/tinkerbell/templates/tink-controller-service-account.yaml
@@ -1,0 +1,7 @@
+{{- if .Values.tinkController.deploy }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.tinkController.name }}
+  namespace: {{ .Values.namespace }}
+{{- end }}

--- a/helm-charts/tinkerbell/templates/tink-leader-election-role.yaml
+++ b/helm-charts/tinkerbell/templates/tink-leader-election-role.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.tinkController.deploy }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Values.tinkController.tinkLeaderElectionRoleName }}
+  namespace: {{ .Values.namespace }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+{{- end }}

--- a/helm-charts/tinkerbell/templates/tink-leader-election-rolebinding.yaml
+++ b/helm-charts/tinkerbell/templates/tink-leader-election-rolebinding.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.tinkController.deploy }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Values.tinkController.tinkLeaderElectionRoleBindingName }}
+  namespace: {{ .Values.namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .Values.tinkController.tinkLeaderElectionRoleName }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.tinkController.name }}
+    namespace: {{ .Values.namespace }}
+{{- end }}

--- a/helm-charts/tinkerbell/templates/tink-server-deployment.yaml
+++ b/helm-charts/tinkerbell/templates/tink-server-deployment.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.tinkServer.deploy }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: {{ .Values.tinkServer.name }}
+  name: {{ .Values.tinkServer.name }}
+  namespace: {{ .Values.namespace }}
+spec:
+  replicas: {{ .Values.tinkServer.replicas }}
+  selector:
+    matchLabels:
+      app: {{ .Values.tinkServer.name }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Values.tinkServer.name }}
+    spec:
+      containers:
+        - args:
+            - --backend=kubernetes
+            {{- range .Values.tinkServer.args }}
+            - {{ . }}
+            {{- end }}
+          image: {{ .Values.tinkServer.image }}
+          imagePullPolicy: {{ .Values.tinkServer.imagePullPolicy }}
+          name: server
+          {{- if .Values.tinkServer.port.hostPortEnabled }}
+          ports:
+            - containerPort: {{ .Values.tinkServer.port.hostPort }}
+              hostPort: {{ .Values.tinkServer.port.hostPort }}
+              name: grpc
+          {{- end }}
+          resources:
+            limits:
+              cpu: {{ .Values.tinkServer.resources.limits.cpu }}
+              memory: {{ .Values.tinkServer.resources.limits.memory }}
+            requests:
+              cpu: {{ .Values.tinkServer.resources.requests.cpu }}
+              memory: {{ .Values.tinkServer.resources.requests.memory }}
+      serviceAccountName: {{ .Values.tinkServer.name }}
+{{- end }}

--- a/helm-charts/tinkerbell/templates/tink-server-role.yaml
+++ b/helm-charts/tinkerbell/templates/tink-server-role.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.tinkServer.deploy }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Values.tinkServer.roleName }}
+  namespace: {{ .Values.namespace }}
+rules:
+  - apiGroups:
+      - tinkerbell.org
+    resources:
+      - hardware
+      - hardware/status
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - tinkerbell.org
+    resources:
+      - templates
+      - templates/status
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - tinkerbell.org
+    resources:
+      - workflows
+      - workflows/status
+    verbs:
+      - get
+      - list
+      - patch
+      - update
+      - watch
+{{- end }}

--- a/helm-charts/tinkerbell/templates/tink-server-rolebinding.yaml
+++ b/helm-charts/tinkerbell/templates/tink-server-rolebinding.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.tinkServer.deploy }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Values.tinkServer.roleBindingName }}
+  namespace: {{ .Values.namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Values.tinkServer.roleName }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.tinkServer.name }}
+    namespace: {{ .Values.namespace }}
+{{- end }}

--- a/helm-charts/tinkerbell/templates/tink-server-service-account.yaml
+++ b/helm-charts/tinkerbell/templates/tink-server-service-account.yaml
@@ -1,0 +1,7 @@
+{{- if .Values.tinkServer.deploy }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.tinkServer.name }}
+  namespace: {{ .Values.namespace }}
+{{- end }}

--- a/helm-charts/tinkerbell/templates/workflow-crd.yaml
+++ b/helm-charts/tinkerbell/templates/workflow-crd.yaml
@@ -1,0 +1,145 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.8.0
+  creationTimestamp: null
+  labels:
+    clusterctl.cluster.x-k8s.io: ""
+    clusterctl.cluster.x-k8s.io/move: "true"
+  name: workflows.tinkerbell.org
+spec:
+  group: tinkerbell.org
+  names:
+    categories:
+      - tinkerbell
+    kind: Workflow
+    listKind: WorkflowList
+    plural: workflows
+    shortNames:
+      - wf
+    singular: workflow
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .spec.templateRef
+          name: Template
+          type: string
+        - jsonPath: .status.state
+          name: State
+          type: string
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: Workflow is the Schema for the Workflows API.
+          properties:
+            apiVersion:
+              description:
+                "APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
+              type: string
+            kind:
+              description:
+                "Kind is a string value representing the REST resource this
+                object represents. Servers may infer this from the endpoint the client
+                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: WorkflowSpec defines the desired state of Workflow.
+              properties:
+                hardwareMap:
+                  additionalProperties:
+                    type: string
+                  description: A mapping of template devices to hadware mac addresses
+                  type: object
+                templateRef:
+                  description: Name of the Template associated with this workflow.
+                  type: string
+              type: object
+            status:
+              description: WorkflowStatus defines the observed state of Workflow.
+              properties:
+                globalTimeout:
+                  description: GlobalTimeout represents the max execution time
+                  format: int64
+                  type: integer
+                state:
+                  description: State is the state of the workflow in Tinkerbell.
+                  type: string
+                tasks:
+                  description: Tasks are the tasks to be completed
+                  items:
+                    description:
+                      Task represents a series of actions to be completed
+                      by a worker.
+                    properties:
+                      actions:
+                        items:
+                          description: Action represents a workflow action.
+                          properties:
+                            command:
+                              items:
+                                type: string
+                              type: array
+                            environment:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            image:
+                              type: string
+                            message:
+                              type: string
+                            name:
+                              type: string
+                            pid:
+                              type: string
+                            seconds:
+                              format: int64
+                              type: integer
+                            startedAt:
+                              format: date-time
+                              type: string
+                            status:
+                              type: string
+                            timeout:
+                              format: int64
+                              type: integer
+                            volumes:
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        type: array
+                      environment:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      name:
+                        type: string
+                      volumes:
+                        items:
+                          type: string
+                        type: array
+                      worker:
+                        type: string
+                    required:
+                      - actions
+                      - name
+                      - worker
+                    type: object
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/helm-charts/tinkerbell/values.yaml
+++ b/helm-charts/tinkerbell/values.yaml
@@ -1,0 +1,83 @@
+# Default values for tinkerbell.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+namespace: tink-system
+createNamespace: true
+
+boots:
+  deploy: true
+  name: boots
+  image: quay.io/tinkerbell/boots:latest
+  imagePullPolicy: IfNotPresent
+  replicas: 1
+  args: ["-dhcp-addr=0.0.0.0:67"]
+  resources:
+    limits:
+      cpu: 500m
+      memory: 128Mi
+    requests:
+      cpu: 10m
+      memory: 64Mi
+  roleName: boots-role
+  roleBindingName: boots-rolebinding
+  env: []
+
+hegel:
+  deploy: true
+  name: hegel
+  image: quay.io/tinkerbell/hegel:latest
+  imagePullPolicy: IfNotPresent
+  replicas: 1
+  port:
+    hostPortEnabled: true
+    hostPort: 50061
+  args: []
+  resources:
+    limits:
+      cpu: 500m
+      memory: 128Mi
+    requests:
+      cpu: 10m
+      memory: 64Mi
+  roleName: hegel-role
+  roleBindingName: hegel-rolebinding
+
+tinkController:
+  deploy: true
+  name: tink-controller-manager
+  image: quay.io/tinkerbell/tink-controller:latest
+  imagePullPolicy: IfNotPresent
+  replicas: 1
+  args: []
+  resources:
+    limits:
+      cpu: 500m
+      memory: 128Mi
+    requests:
+      cpu: 10m
+      memory: 64Mi
+  roleName: tink-controller-manager-role
+  roleBindingName: tink-controller-manager-rolebinding
+  tinkLeaderElectionRoleName: tink-leader-election-role
+  tinkLeaderElectionRoleBindingName: tink-leader-election-rolebinding
+
+tinkServer:
+  deploy: true
+  name: tink-server
+  image: quay.io/tinkerbell/tink-server:latest
+  imagePullPolicy: IfNotPresent
+  replicas: 1
+  port:
+    hostPortEnabled: true
+    hostPort: 42113
+  args: []
+  resources:
+    limits:
+      cpu: 500m
+      memory: 128Mi
+    requests:
+      cpu: 10m
+      memory: 64Mi
+  roleName: tink-server-role
+  roleBindingName: tink-server-rolebinding


### PR DESCRIPTION
## Description
Adding helm chart to deploy Tinkerbell in Kubernetes

## Why is this needed
Makes deploying Tinkerbell in Kubernetes easier

## How Has This Been Tested?
Ran `make helm` and verified the package by deploying it to k8s

## How are existing users impacted? What migration steps/scripts do we need?
No existing user impact

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
