### PR TITLE
Use /cert less images, newer hook and some more docker-compose clean ups.

### DIFF
--- a/deploy/compose/.env
+++ b/deploy/compose/.env
@@ -1,6 +1,6 @@
 # These must be defined above/before first use.
 # Use of these variables *must* be in ${} form, otherwise docker-compose won't substitute when processing this file
-vOSIE=5.10.57
+vOSIE=v0.7.0
 vTINK=sha-0a800a4b
 
 # Probably don't want to mess with these, unless you know you do

--- a/deploy/compose/.env
+++ b/deploy/compose/.env
@@ -3,12 +3,14 @@
 vOSIE=5.10.57
 vTINK=sha-0a800a4b
 
-OSIE_DOWNLOAD_URLS=https://github.com/tinkerbell/hook/releases/download/${vOSIE}/hook_x86_64.tar.gz,https://github.com/tinkerbell/hook/releases/download/${vOSIE}/hook_aarch64.tar.gz
+# Probably don't want to mess with these, unless you know you do
+FACILITY=onprem
+TINKERBELL_REGISTRY_PASSWORD=Admin1234
+TINKERBELL_REGISTRY_USERNAME=admin
+TINKERBELL_TLS= false
 
-BOOTS_IMAGE=quay.io/tinkerbell/boots:sha-505785d7
-HEGEL_IMAGE=quay.io/tinkerbell/hegel:sha-592588cf
-TINK_CLI_IMAGE=quay.io/tinkerbell/tink-cli:${vTINK}
-TINK_SERVER_IMAGE=quay.io/tinkerbell/tink:${vTINK}
+# Can be set to your own hook builds
+OSIE_DOWNLOAD_URLS=https://github.com/tinkerbell/hook/releases/download/${vOSIE}/hook_x86_64.tar.gz,https://github.com/tinkerbell/hook/releases/download/${vOSIE}/hook_aarch64.tar.gz
 
 TINKERBELL_HARDWARE_MANIFEST=/manifests/hardware/hardware.json
 TINKERBELL_TEMPLATE_MANIFEST=/manifests/template/ubuntu.yaml
@@ -16,3 +18,9 @@ TINKERBELL_TEMPLATE_MANIFEST=/manifests/template/ubuntu.yaml
 TINKERBELL_CLIENT_IP=192.168.56.43
 TINKERBELL_CLIENT_MAC=08:00:27:9e:f5:3a
 TINKERBELL_HOST_IP=192.168.56.4
+
+# Images used by docker-compose natively or in terraform/vagrant, update if necessary
+BOOTS_IMAGE=quay.io/tinkerbell/boots:sha-505785d7
+HEGEL_IMAGE=quay.io/tinkerbell/hegel:sha-592588cf
+TINK_CLI_IMAGE=quay.io/tinkerbell/tink-cli:${vTINK}
+TINK_SERVER_IMAGE=quay.io/tinkerbell/tink:${vTINK}

--- a/deploy/compose/.env
+++ b/deploy/compose/.env
@@ -1,9 +1,14 @@
-OSIE_DOWNLOAD_URLS=https://github.com/tinkerbell/hook/releases/download/5.10.57/hook_x86_64.tar.gz,https://github.com/tinkerbell/hook/releases/download/5.10.57/hook_aarch64.tar.gz
+# These must be defined above/before first use.
+# Use of these variables *must* be in ${} form, otherwise docker-compose won't substitute when processing this file
+vOSIE=5.10.57
+vTINK=sha-0a800a4b
 
-BOOTS_SERVER_IMAGE=quay.io/tinkerbell/boots:sha-505785d7
-HEGEL_SERVER_IMAGE=quay.io/tinkerbell/hegel:sha-592588cf
-TINK_CLI_IMAGE=quay.io/tinkerbell/tink-cli:sha-0a800a4b
-TINK_SERVER_IMAGE=quay.io/tinkerbell/tink:sha-0a800a4b
+OSIE_DOWNLOAD_URLS=https://github.com/tinkerbell/hook/releases/download/${vOSIE}/hook_x86_64.tar.gz,https://github.com/tinkerbell/hook/releases/download/${vOSIE}/hook_aarch64.tar.gz
+
+BOOTS_IMAGE=quay.io/tinkerbell/boots:sha-505785d7
+HEGEL_IMAGE=quay.io/tinkerbell/hegel:sha-592588cf
+TINK_CLI_IMAGE=quay.io/tinkerbell/tink-cli:${vTINK}
+TINK_SERVER_IMAGE=quay.io/tinkerbell/tink:${vTINK}
 
 TINKERBELL_HARDWARE_MANIFEST=/manifests/hardware/hardware.json
 TINKERBELL_TEMPLATE_MANIFEST=/manifests/template/ubuntu.yaml

--- a/deploy/compose/.env
+++ b/deploy/compose/.env
@@ -1,9 +1,9 @@
 OSIE_DOWNLOAD_URLS=https://github.com/tinkerbell/hook/releases/download/5.10.57/hook_x86_64.tar.gz,https://github.com/tinkerbell/hook/releases/download/5.10.57/hook_aarch64.tar.gz
 
-BOOTS_SERVER_IMAGE=quay.io/tinkerbell/boots:sha-36f12f81
-HEGEL_SERVER_IMAGE=quay.io/tinkerbell/hegel:sha-89cb9dc8
-TINK_CLI_IMAGE=quay.io/tinkerbell/tink-cli:sha-e053ada6
-TINK_SERVER_IMAGE=quay.io/tinkerbell/tink:sha-3743d31e
+BOOTS_SERVER_IMAGE=quay.io/tinkerbell/boots:sha-505785d7
+HEGEL_SERVER_IMAGE=quay.io/tinkerbell/hegel:sha-592588cf
+TINK_CLI_IMAGE=quay.io/tinkerbell/tink-cli:sha-0a800a4b
+TINK_SERVER_IMAGE=quay.io/tinkerbell/tink:sha-0a800a4b
 
 TINKERBELL_HARDWARE_MANIFEST=/manifests/hardware/hardware.json
 TINKERBELL_TEMPLATE_MANIFEST=/manifests/template/ubuntu.yaml

--- a/deploy/compose/.env
+++ b/deploy/compose/.env
@@ -24,3 +24,4 @@ BOOTS_IMAGE=quay.io/tinkerbell/boots:sha-505785d7
 HEGEL_IMAGE=quay.io/tinkerbell/hegel:sha-592588cf
 TINK_CLI_IMAGE=quay.io/tinkerbell/tink-cli:${vTINK}
 TINK_SERVER_IMAGE=quay.io/tinkerbell/tink:${vTINK}
+TINK_WORKER_IMAGE=quay.io/tinkerbell/tink-worker:${vTINK}

--- a/deploy/compose/create-tink-records/create.sh
+++ b/deploy/compose/create-tink-records/create.sh
@@ -2,7 +2,7 @@
 
 # This script is used to push (hardware) and create (template, workflow) Tink Server data/objects
 # This script assumes that the `tink` binary is in the PATH and
-# TINKERBELL_CERT_URL and TINKERBELL_GRPC_AUTHORITY environment variables are set
+# TINKERBELL_GRPC_AUTHORITY and TINKERBELL_TLS environment variables are set as necessary
 # See https://docs.tinkerbell.org/services/tink-cli/ for more details
 
 set -euxo pipefail

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       DOCKER_REGISTRY: $TINKERBELL_HOST_IP
       FACILITY_CODE: ${FACILITY:-onprem}
       HTTP_BIND: $TINKERBELL_HOST_IP:80
-      MIRROR_HOST: ${TINKERBELL_HOST_IP:-127.0.0.1}:8080
+      MIRROR_BASE_URL: http://$TINKERBELL_HOST_IP:8080
       PACKET_ENV: ${PACKET_ENV:-testing}
       PACKET_VERSION: ${PACKET_VERSION:-ignored}
       PUBLIC_IP: $TINKERBELL_HOST_IP
@@ -25,6 +25,7 @@ services:
       TFTP_BIND: $TINKERBELL_HOST_IP:69
       TINKERBELL_CERT_URL: http://$TINKERBELL_HOST_IP:42114/cert
       TINKERBELL_GRPC_AUTHORITY: $TINKERBELL_HOST_IP:42113
+      TINKERBELL_TLS: ${TINKERBELL_TLS:-false}
     extra_hosts:
       - tink-server:$TINKERBELL_HOST_IP
     depends_on:
@@ -75,6 +76,7 @@ services:
       ROLLBAR_TOKEN: ${ROLLBAR_TOKEN-ignored}
       TINKERBELL_CERT_URL: http://tink-server:42114/cert
       TINKERBELL_GRPC_AUTHORITY: tink-server:42113
+      TINKERBELL_TLS: ${TINKERBELL_TLS:-false}
     ports:
       - 50060:50060/tcp
       - 50061:50061/tcp
@@ -140,6 +142,7 @@ services:
       TINK_AUTH_USERNAME: ${TINKERBELL_TINK_USERNAME:-admin}
       TINKERBELL_GRPC_AUTHORITY: :42113
       TINKERBELL_HTTP_AUTHORITY: :42114
+      TINKERBELL_TLS: ${TINKERBELL_TLS:-false}
     volumes:
       - certs:/certs/${FACILITY:-onprem}:ro
     ports:
@@ -199,6 +202,7 @@ services:
       TINKERBELL_HARDWARE_MANIFEST: $TINKERBELL_HARDWARE_MANIFEST
       TINKERBELL_HOST_IP: $TINKERBELL_HOST_IP
       TINKERBELL_TEMPLATE_MANIFEST: $TINKERBELL_TEMPLATE_MANIFEST
+      TINKERBELL_TLS: ${TINKERBELL_TLS:-false}
     volumes:
       - ./create-tink-records/create.sh:/app/create.sh:ro
       - ./create-tink-records/manifests:/manifests:ro
@@ -223,6 +227,7 @@ services:
       TINK_AUTH_USERNAME: ${TINKERBELL_TINK_USERNAME:-admin}
       TINKERBELL_GRPC_AUTHORITY: :42113
       TINKERBELL_HTTP_AUTHORITY: :42114
+      TINKERBELL_TLS: ${TINKERBELL_TLS:-false}
     volumes:
       - certs:/certs/${FACILITY:-onprem}:ro
     depends_on:
@@ -280,6 +285,7 @@ services:
     environment:
       TINKERBELL_CERT_URL: http://tink-server:42114/cert
       TINKERBELL_GRPC_AUTHORITY: tink-server:42113
+      TINKERBELL_TLS: ${TINKERBELL_TLS:-false}
     depends_on:
       db:
         condition: service_healthy

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   ##### Actual services first #####
   boots:
     image: ${BOOTS_SERVER_IMAGE}
-    command: -dhcp-addr 0.0.0.0:67 -tftp-addr $TINKERBELL_HOST_IP:69 -http-addr $TINKERBELL_HOST_IP:80 -log-level DEBUG
+    command: -dhcp-addr 0.0.0.0:67 -tftp-addr "$TINKERBELL_HOST_IP:69" -http-addr "$TINKERBELL_HOST_IP:80" -log-level DEBUG
     network_mode: host
     environment:
       API_AUTH_TOKEN: ${PACKET_API_AUTH_TOKEN:-ignored}
@@ -26,7 +26,7 @@ services:
       TINKERBELL_CERT_URL: http://$TINKERBELL_HOST_IP:42114/cert
       TINKERBELL_GRPC_AUTHORITY: $TINKERBELL_HOST_IP:42113
     extra_hosts:
-      - "tink-server:$TINKERBELL_HOST_IP"
+      - tink-server:$TINKERBELL_HOST_IP
     depends_on:
       tink-server:
         condition: service_healthy
@@ -34,7 +34,7 @@ services:
       resources:
         limits:
           cpus: "0.50"
-          memory: "512M"
+          memory: 512M
     restart: unless-stopped
 
   db:
@@ -51,7 +51,7 @@ services:
       resources:
         limits:
           cpus: "0.50"
-          memory: "512M"
+          memory: 512M
     healthcheck:
       test:
         - CMD-SHELL
@@ -85,7 +85,7 @@ services:
       resources:
         limits:
           cpus: "0.50"
-          memory: "512M"
+          memory: 512M
     restart: unless-stopped
 
   registry:
@@ -112,11 +112,11 @@ services:
       resources:
         limits:
           cpus: "0.50"
-          memory: "512M"
+          memory: 512M
     healthcheck:
       test:
         - CMD-SHELL
-        - wget --no-check-certificate https://$TINKERBELL_HOST_IP -O - >/dev/null
+        - wget --no-check-certificate "https://$TINKERBELL_HOST_IP" -O - >/dev/null
       interval: 5s
       timeout: 1s
       retries: 5
@@ -156,7 +156,7 @@ services:
       resources:
         limits:
           cpus: "0.50"
-          memory: "512M"
+          memory: 512M
     healthcheck:
       # port needs to match TINKERBELL_HTTP_AUTHORITY
       test:
@@ -184,7 +184,7 @@ services:
       resources:
         limits:
           cpus: "0.50"
-          memory: "512M"
+          memory: 512M
     restart: unless-stopped
 
   ##### One-off setup processes #####
@@ -232,7 +232,7 @@ services:
 
   fetch-osie:
     image: bash:4.4
-    command: /app/fetch.sh ${OSIE_DOWNLOAD_URLS} /workdir
+    command: /app/fetch.sh "${OSIE_DOWNLOAD_URLS}" /workdir
     volumes:
       - ./fetch-osie/fetch.sh:/app/fetch.sh:ro
       - ./state/webroot/misc/osie/current:/workdir
@@ -256,7 +256,7 @@ services:
   generate-tls-certs:
     image: cfssl/cfssl
     entrypoint: /app/generate.sh
-    command: "$TINKERBELL_HOST_IP"
+    command: '"$TINKERBELL_HOST_IP"'
     environment:
       FACILITY: ${FACILITY:-onprem}
     volumes:
@@ -289,7 +289,7 @@ services:
       resources:
         limits:
           cpus: "0.50"
-          memory: "512M"
+          memory: 512M
     restart: unless-stopped
 
 volumes:

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -161,7 +161,7 @@ services:
       # port needs to match TINKERBELL_HTTP_AUTHORITY
       test:
         - CMD-SHELL
-        - wget -qO- 127.0.0.1:42114/cert
+        - wget -qO- 127.0.0.1:42114/healthz
       interval: 5s
       timeout: 2s
       retries: 30

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -9,16 +9,16 @@ services:
       DATA_MODEL_VERSION: 1
       DNS_SERVERS: 8.8.8.8
       DOCKER_REGISTRY: $TINKERBELL_HOST_IP
-      FACILITY_CODE: ${FACILITY:-onprem}
+      FACILITY_CODE: $FACILITY
       HTTP_BIND: $TINKERBELL_HOST_IP:80
       MIRROR_BASE_URL: http://$TINKERBELL_HOST_IP:8080
       PUBLIC_IP: $TINKERBELL_HOST_IP
-      REGISTRY_PASSWORD: ${TINKERBELL_REGISTRY_PASSWORD:-Admin1234}
-      REGISTRY_USERNAME: ${TINKERBELL_REGISTRY_USERNAME:-admin}
+      REGISTRY_PASSWORD: $TINKERBELL_REGISTRY_PASSWORD
+      REGISTRY_USERNAME: $TINKERBELL_REGISTRY_USERNAME
       SYSLOG_BIND: $TINKERBELL_HOST_IP:514
       TFTP_BIND: $TINKERBELL_HOST_IP:69
       TINKERBELL_GRPC_AUTHORITY: $TINKERBELL_HOST_IP:42113
-      TINKERBELL_TLS: ${TINKERBELL_TLS:-false}
+      TINKERBELL_TLS: $TINKERBELL_TLS
     extra_hosts:
       - tink-server:$TINKERBELL_HOST_IP
     depends_on:
@@ -61,10 +61,10 @@ services:
       CUSTOM_ENDPOINTS: '{"/metadata":""}'
       DATA_MODEL_VERSION: 1
       GRPC_PORT: 42115
-      HEGEL_FACILITY: ${FACILITY:-onprem}
+      HEGEL_FACILITY: $FACILITY
       HEGEL_USE_TLS: 0
       TINKERBELL_GRPC_AUTHORITY: tink-server:42113
-      TINKERBELL_TLS: ${TINKERBELL_TLS:-false}
+      TINKERBELL_TLS: $TINKERBELL_TLS
     ports:
       - 50060:50060/tcp
       - 50061:50061/tcp
@@ -85,13 +85,13 @@ services:
       REGISTRY_AUTH_HTPASSWD_PATH: /auth/.htpasswd
       REGISTRY_AUTH_HTPASSWD_REALM: Registry Realm
       REGISTRY_HTTP_ADDR: $TINKERBELL_HOST_IP:443
-      REGISTRY_HTTP_TLS_CERTIFICATE: /certs/${FACILITY:-onprem}/server-crt.pem
-      REGISTRY_HTTP_TLS_KEY: /certs/${FACILITY:-onprem}/server-key.pem
+      REGISTRY_HTTP_TLS_CERTIFICATE: /certs/$FACILITY/server-crt.pem
+      REGISTRY_HTTP_TLS_KEY: /certs/$FACILITY/server-key.pem
     init: true
     network_mode: host
     volumes:
       - auth:/auth:ro
-      - certs:/certs/${FACILITY:-onprem}:ro
+      - certs:/certs/$FACILITY:ro
       - registry_data:/var/lib/registry
     depends_on:
       generate-tls-certs:
@@ -115,7 +115,7 @@ services:
   tink-server:
     image: ${TINK_SERVER_IMAGE}
     environment:
-      FACILITY: ${FACILITY:-onprem}
+      FACILITY: $FACILITY
       PGDATABASE: tinkerbell
       PGHOST: db
       PGPASSWORD: tinkerbell
@@ -124,9 +124,9 @@ services:
       PGUSER: tinkerbell
       TINKERBELL_GRPC_AUTHORITY: :42113
       TINKERBELL_HTTP_AUTHORITY: :42114
-      TINKERBELL_TLS: ${TINKERBELL_TLS:-false}
+      TINKERBELL_TLS: $TINKERBELL_TLS
     volumes:
-      - certs:/certs/${FACILITY:-onprem}:ro
+      - certs:/certs/$FACILITY:ro
     ports:
       - 42113:42113/tcp
       - 42114:42114/tcp
@@ -177,13 +177,8 @@ services:
     image: ${TINK_CLI_IMAGE}
     command: /app/create.sh "$TINKERBELL_HARDWARE_MANIFEST" "$TINKERBELL_TEMPLATE_MANIFEST" "$TINKERBELL_HOST_IP" "$TINKERBELL_CLIENT_IP" "$TINKERBELL_CLIENT_MAC"
     environment:
-      TINKERBELL_CLIENT_IP: $TINKERBELL_CLIENT_IP
-      TINKERBELL_CLIENT_MAC: $TINKERBELL_CLIENT_MAC
       TINKERBELL_GRPC_AUTHORITY: tink-server:42113
-      TINKERBELL_HARDWARE_MANIFEST: $TINKERBELL_HARDWARE_MANIFEST
-      TINKERBELL_HOST_IP: $TINKERBELL_HOST_IP
-      TINKERBELL_TEMPLATE_MANIFEST: $TINKERBELL_TEMPLATE_MANIFEST
-      TINKERBELL_TLS: ${TINKERBELL_TLS:-false}
+      TINKERBELL_TLS: $TINKERBELL_TLS
     volumes:
       - ./create-tink-records/create.sh:/app/create.sh:ro
       - ./create-tink-records/manifests:/manifests:ro
@@ -196,7 +191,7 @@ services:
   db-migrations:
     image: ${TINK_SERVER_IMAGE}
     environment:
-      FACILITY: ${FACILITY:-onprem}
+      FACILITY: $FACILITY
       ONLY_MIGRATION: "true"
       PGDATABASE: tinkerbell
       PGHOST: db
@@ -204,11 +199,9 @@ services:
       PGPORT: 5432
       PGSSLMODE: disable
       PGUSER: tinkerbell
-      TINKERBELL_GRPC_AUTHORITY: :42113
-      TINKERBELL_HTTP_AUTHORITY: :42114
-      TINKERBELL_TLS: ${TINKERBELL_TLS:-false}
+      TINKERBELL_TLS: $TINKERBELL_TLS
     volumes:
-      - certs:/certs/${FACILITY:-onprem}:ro
+      - certs:/certs/$FACILITY:ro
     depends_on:
       db:
         condition: service_healthy
@@ -232,7 +225,7 @@ services:
   generate-registry-auth:
     image: httpd:2
     entrypoint: htpasswd
-    command: -Bbc .htpasswd "${TINKERBELL_REGISTRY_USERNAME:-admin}" "${TINKERBELL_REGISTRY_PASSWORD:-Admin1234}"
+    command: -Bbc .htpasswd "${TINKERBELL_REGISTRY_USERNAME}" "${TINKERBELL_REGISTRY_PASSWORD}"
     working_dir: /auth
     volumes:
       - auth:/auth
@@ -240,18 +233,19 @@ services:
   generate-tls-certs:
     image: cfssl/cfssl
     entrypoint: /app/generate.sh
-    command: '"$TINKERBELL_HOST_IP"'
+    command: "$TINKERBELL_HOST_IP"
     environment:
-      FACILITY: ${FACILITY:-onprem}
+      FACILITY: $FACILITY
+      TINKERBELL_HOST_IP: $TINKERBELL_HOST_IP
     volumes:
-      - certs:/certs/${FACILITY:-onprem}
+      - certs:/certs/$FACILITY
       - ./generate-tls-certs/:/app:ro
       - ./state/webroot/workflow/:/workflow/
 
   sync-images-to-local-registry:
     image: quay.io/containers/skopeo:v1.4.1
     entrypoint: /bin/bash
-    command: /app/upload.sh "${TINKERBELL_REGISTRY_USERNAME:-admin}" "${TINKERBELL_REGISTRY_PASSWORD:-Admin1234}" "${TINKERBELL_HOST_IP}" /app/registry_images.txt
+    command: /app/upload.sh "${TINKERBELL_REGISTRY_USERNAME}" "${TINKERBELL_REGISTRY_PASSWORD}" "${TINKERBELL_HOST_IP}" /app/registry_images.txt
     volumes:
       - ./sync-images-to-local-registry:/app:ro
     depends_on:
@@ -263,7 +257,7 @@ services:
     image: ${TINK_CLI_IMAGE}
     environment:
       TINKERBELL_GRPC_AUTHORITY: tink-server:42113
-      TINKERBELL_TLS: ${TINKERBELL_TLS:-false}
+      TINKERBELL_TLS: $TINKERBELL_TLS
     depends_on:
       db:
         condition: service_healthy

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   ##### Actual services first #####
   boots:
-    image: ${BOOTS_SERVER_IMAGE}
+    image: ${BOOTS_IMAGE}
     command: -log-level DEBUG
     network_mode: host
     environment:
@@ -56,7 +56,7 @@ services:
     restart: unless-stopped
 
   hegel:
-    image: ${HEGEL_SERVER_IMAGE}
+    image: ${HEGEL_IMAGE}
     environment:
       CUSTOM_ENDPOINTS: '{"/metadata":""}'
       DATA_MODEL_VERSION: 1

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -2,12 +2,12 @@ services:
   ##### Actual services first #####
   boots:
     image: ${BOOTS_SERVER_IMAGE}
-    command: -dhcp-addr 0.0.0.0:67 -tftp-addr "$TINKERBELL_HOST_IP:69" -http-addr "$TINKERBELL_HOST_IP:80" -log-level DEBUG
+    command: -log-level DEBUG
     network_mode: host
     environment:
       API_AUTH_TOKEN: ${PACKET_API_AUTH_TOKEN:-ignored}
       API_CONSUMER_TOKEN: ${PACKET_CONSUMER_TOKEN:-ignored}
-      BOOTP_BIND: $TINKERBELL_HOST_IP:67
+      BOOTP_BIND: 0.0.0.0:67
       DATA_MODEL_VERSION: 1
       DNS_SERVERS: 8.8.8.8
       DOCKER_REGISTRY: $TINKERBELL_HOST_IP

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -5,8 +5,6 @@ services:
     command: -log-level DEBUG
     network_mode: host
     environment:
-      API_AUTH_TOKEN: ${PACKET_API_AUTH_TOKEN:-ignored}
-      API_CONSUMER_TOKEN: ${PACKET_CONSUMER_TOKEN:-ignored}
       BOOTP_BIND: 0.0.0.0:67
       DATA_MODEL_VERSION: 1
       DNS_SERVERS: 8.8.8.8
@@ -14,16 +12,11 @@ services:
       FACILITY_CODE: ${FACILITY:-onprem}
       HTTP_BIND: $TINKERBELL_HOST_IP:80
       MIRROR_BASE_URL: http://$TINKERBELL_HOST_IP:8080
-      PACKET_ENV: ${PACKET_ENV:-testing}
-      PACKET_VERSION: ${PACKET_VERSION:-ignored}
       PUBLIC_IP: $TINKERBELL_HOST_IP
       REGISTRY_PASSWORD: ${TINKERBELL_REGISTRY_PASSWORD:-Admin1234}
       REGISTRY_USERNAME: ${TINKERBELL_REGISTRY_USERNAME:-admin}
-      ROLLBAR_DISABLE: ${ROLLBAR_DISABLE:-1}
-      ROLLBAR_TOKEN: ${ROLLBAR_TOKEN:-ignored}
       SYSLOG_BIND: $TINKERBELL_HOST_IP:514
       TFTP_BIND: $TINKERBELL_HOST_IP:69
-      TINKERBELL_CERT_URL: http://$TINKERBELL_HOST_IP:42114/cert
       TINKERBELL_GRPC_AUTHORITY: $TINKERBELL_HOST_IP:42113
       TINKERBELL_TLS: ${TINKERBELL_TLS:-false}
     extra_hosts:
@@ -70,11 +63,6 @@ services:
       GRPC_PORT: 42115
       HEGEL_FACILITY: ${FACILITY:-onprem}
       HEGEL_USE_TLS: 0
-      PACKET_ENV: testing
-      PACKET_VERSION: ${PACKET_VERSION:-ignored}
-      ROLLBAR_DISABLE: 1
-      ROLLBAR_TOKEN: ${ROLLBAR_TOKEN-ignored}
-      TINKERBELL_CERT_URL: http://tink-server:42114/cert
       TINKERBELL_GRPC_AUTHORITY: tink-server:42113
       TINKERBELL_TLS: ${TINKERBELL_TLS:-false}
     ports:
@@ -128,18 +116,12 @@ services:
     image: ${TINK_SERVER_IMAGE}
     environment:
       FACILITY: ${FACILITY:-onprem}
-      PACKET_ENV: ${PACKET_ENV:-testing}
-      PACKET_VERSION: ${PACKET_VERSION:-ignored}
       PGDATABASE: tinkerbell
       PGHOST: db
       PGPASSWORD: tinkerbell
       PGPORT: 5432
       PGSSLMODE: disable
       PGUSER: tinkerbell
-      ROLLBAR_DISABLE: ${ROLLBAR_DISABLE:-1}
-      ROLLBAR_TOKEN: ${ROLLBAR_TOKEN:-ignored}
-      TINK_AUTH_PASSWORD: ${TINKERBELL_TINK_PASSWORD:-admin}
-      TINK_AUTH_USERNAME: ${TINKERBELL_TINK_USERNAME:-admin}
       TINKERBELL_GRPC_AUTHORITY: :42113
       TINKERBELL_HTTP_AUTHORITY: :42114
       TINKERBELL_TLS: ${TINKERBELL_TLS:-false}
@@ -195,7 +177,6 @@ services:
     image: ${TINK_CLI_IMAGE}
     command: /app/create.sh "$TINKERBELL_HARDWARE_MANIFEST" "$TINKERBELL_TEMPLATE_MANIFEST" "$TINKERBELL_HOST_IP" "$TINKERBELL_CLIENT_IP" "$TINKERBELL_CLIENT_MAC"
     environment:
-      TINKERBELL_CERT_URL: http://tink-server:42114/cert
       TINKERBELL_CLIENT_IP: $TINKERBELL_CLIENT_IP
       TINKERBELL_CLIENT_MAC: $TINKERBELL_CLIENT_MAC
       TINKERBELL_GRPC_AUTHORITY: tink-server:42113
@@ -223,8 +204,6 @@ services:
       PGPORT: 5432
       PGSSLMODE: disable
       PGUSER: tinkerbell
-      TINK_AUTH_PASSWORD: ${TINKERBELL_TINK_PASSWORD:-admin}
-      TINK_AUTH_USERNAME: ${TINKERBELL_TINK_USERNAME:-admin}
       TINKERBELL_GRPC_AUTHORITY: :42113
       TINKERBELL_HTTP_AUTHORITY: :42114
       TINKERBELL_TLS: ${TINKERBELL_TLS:-false}
@@ -283,7 +262,6 @@ services:
   tink-cli:
     image: ${TINK_CLI_IMAGE}
     environment:
-      TINKERBELL_CERT_URL: http://tink-server:42114/cert
       TINKERBELL_GRPC_AUTHORITY: tink-server:42113
       TINKERBELL_TLS: ${TINKERBELL_TLS:-false}
     depends_on:

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   ##### Actual services first #####
   boots:
-    image: ${BOOTS_IMAGE}
+    image: $BOOTS_IMAGE
     command: -log-level DEBUG
     network_mode: host
     environment:
@@ -56,7 +56,7 @@ services:
     restart: unless-stopped
 
   hegel:
-    image: ${HEGEL_IMAGE}
+    image: $HEGEL_IMAGE
     environment:
       CUSTOM_ENDPOINTS: '{"/metadata":""}'
       DATA_MODEL_VERSION: 1
@@ -113,7 +113,7 @@ services:
     restart: unless-stopped
 
   tink-server:
-    image: ${TINK_SERVER_IMAGE}
+    image: $TINK_SERVER_IMAGE
     environment:
       FACILITY: $FACILITY
       PGDATABASE: tinkerbell
@@ -174,7 +174,7 @@ services:
 
   ##### One-off setup processes #####
   create-tink-records:
-    image: ${TINK_CLI_IMAGE}
+    image: $TINK_CLI_IMAGE
     command: /app/create.sh "$TINKERBELL_HARDWARE_MANIFEST" "$TINKERBELL_TEMPLATE_MANIFEST" "$TINKERBELL_HOST_IP" "$TINKERBELL_CLIENT_IP" "$TINKERBELL_CLIENT_MAC"
     environment:
       TINKERBELL_GRPC_AUTHORITY: tink-server:42113
@@ -189,7 +189,7 @@ services:
         condition: service_healthy
 
   db-migrations:
-    image: ${TINK_SERVER_IMAGE}
+    image: $TINK_SERVER_IMAGE
     environment:
       FACILITY: $FACILITY
       ONLY_MIGRATION: "true"
@@ -209,7 +209,7 @@ services:
 
   fetch-osie:
     image: bash:4.4
-    command: /app/fetch.sh "${OSIE_DOWNLOAD_URLS}" /workdir
+    command: /app/fetch.sh "$OSIE_DOWNLOAD_URLS" /workdir
     volumes:
       - ./fetch-osie/fetch.sh:/app/fetch.sh:ro
       - ./state/webroot/misc/osie/current:/workdir
@@ -225,7 +225,7 @@ services:
   generate-registry-auth:
     image: httpd:2
     entrypoint: htpasswd
-    command: -Bbc .htpasswd "${TINKERBELL_REGISTRY_USERNAME}" "${TINKERBELL_REGISTRY_PASSWORD}"
+    command: -Bbc .htpasswd "$TINKERBELL_REGISTRY_USERNAME" "$TINKERBELL_REGISTRY_PASSWORD"
     working_dir: /auth
     volumes:
       - auth:/auth
@@ -245,7 +245,7 @@ services:
   sync-images-to-local-registry:
     image: quay.io/containers/skopeo:v1.4.1
     entrypoint: /bin/bash
-    command: /app/upload.sh "${TINKERBELL_REGISTRY_USERNAME}" "${TINKERBELL_REGISTRY_PASSWORD}" "${TINKERBELL_HOST_IP}" /app/registry_images.txt
+    command: /app/upload.sh "$TINKERBELL_REGISTRY_USERNAME" "$TINKERBELL_REGISTRY_PASSWORD" "$TINKERBELL_HOST_IP" /app/registry_images.txt
     volumes:
       - ./sync-images-to-local-registry:/app:ro
     depends_on:
@@ -254,7 +254,7 @@ services:
 
   ##### Debugging/interactive commands #####
   tink-cli:
-    image: ${TINK_CLI_IMAGE}
+    image: $TINK_CLI_IMAGE
     environment:
       TINKERBELL_GRPC_AUTHORITY: tink-server:42113
       TINKERBELL_TLS: $TINKERBELL_TLS

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -245,7 +245,7 @@ services:
   sync-images-to-local-registry:
     image: quay.io/containers/skopeo:v1.4.1
     entrypoint: /bin/bash
-    command: /app/upload.sh "$TINKERBELL_REGISTRY_USERNAME" "$TINKERBELL_REGISTRY_PASSWORD" "$TINKERBELL_HOST_IP" /app/registry_images.txt
+    command: /app/upload.sh "$TINKERBELL_REGISTRY_USERNAME" "$TINKERBELL_REGISTRY_PASSWORD" "$TINKERBELL_HOST_IP" "$TINK_WORKER_IMAGE" /app/registry_images.txt
     volumes:
       - ./sync-images-to-local-registry:/app:ro
     depends_on:

--- a/deploy/compose/sync-images-to-local-registry/registry_images.txt
+++ b/deploy/compose/sync-images-to-local-registry/registry_images.txt
@@ -1,4 +1,4 @@
-quay.io/tinkerbell/tink-worker:sha-3743d31e tink-worker:latest
+@TINK_WORKER_IMAGE@ tink-worker:latest
 quay.io/tinkerbell-actions/image2disk:v1.0.0 image2disk:v1.0.0
 quay.io/tinkerbell-actions/cexec:v1.0.0 cexec:v1.0.0
 quay.io/tinkerbell-actions/writefile:v1.0.0 writefile:v1.0.0

--- a/deploy/compose/sync-images-to-local-registry/upload.sh
+++ b/deploy/compose/sync-images-to-local-registry/upload.sh
@@ -8,9 +8,10 @@ set -euo pipefail
 user=$1
 pass=$2
 url=$3
-images=$4
+tink_image=$4
+images=$5
 
-mapfile -t lines <"$images"
+mapfile -t lines < <(sed 's|@TINK_WORKER_IMAGE@|'"$tink_image"'|' "$images")
 printf "syncing:\n" >&2
 printf "%s\n" "${lines[@]}" | sed 's| | → |' >&2
 for l in "${lines[@]}"; do

--- a/deploy/terraform/setup.sh
+++ b/deploy/terraform/setup.sh
@@ -171,4 +171,5 @@ if [[ ${BASH_SOURCE[0]} == "$0" ]]; then
 	set -euxo pipefail
 
 	main "$@"
+	echo "all done!"
 fi

--- a/deploy/vagrant/setup.sh
+++ b/deploy/vagrant/setup.sh
@@ -96,4 +96,5 @@ if [[ ${BASH_SOURCE[0]} == "$0" ]]; then
 	set -euxo pipefail
 
 	main "$@"
+	echo "all done!"
 fi

--- a/shell.nix
+++ b/shell.nix
@@ -2,9 +2,9 @@ let _pkgs = import <nixpkgs> { };
 in { pkgs ? import (_pkgs.fetchFromGitHub {
   owner = "NixOS";
   repo = "nixpkgs";
-  #branch@date: master@2021-03-18
-  rev = "800a3dd90970a277e3f6853633bd7faf04d6691e";
-  sha256 = "07gzvf3m3vh9kkig2x9iybv8yr04kvmrx665z0fb0n5h55ha4v8y";
+  #branch@date: master@2022-06-02
+  rev = "17e891b141ca8e599ebf6443d0870a67dd98f94f";
+  sha256 = "0qiyl04s4q0b3dhvyryz10hfdqhb2c7hk2lqn5llsb8lxsqj07l9";
 }) { } }:
 
 with pkgs;


### PR DESCRIPTION
## Description

- Update nixpkgs to get a newer docker-compose
- Echo a message when setup.sh is all done
- Change tink-server healthcheck endpoint to healthz instead of fetching /cert
- Ensure command line args are always double quoted
- Get rid of conflicting boots listen address values
- Update boots/hegel/tink* container images to latest sha
- Drop useless env vars (both packet/em specific and outdated ones)
- Keep versions in variables for DRYness
- Move all configurable env vars to .env (also for DRYness)
- Specify the same version of tink-worker as tink-serve and tink-cli to hook
- Update hook to v0.7.0

## Why is this needed

Two main things going on in this PR. First is cleaning up both the docker-compose.yml and .env files so that the docker-compose file can be written as if all the envvars it wants are always specified. Actual environment variables still supersede the values in .env like they also supersede when `${NAME:-default}` is specified in the docker-compose.yml file. All in all this means we only need to specify the value of an env var with default once instead of all over the docker-compose.yml file.

The other thing going on in this PR is updates to all the container images and the version of hook being used. The container images have been updated to a relatively recent version that no longer serves or fetches the grpc tls cert via the /cert http url endpoint. The version of Hook has been updated too since the previously used one is almost a year old and thus we haven't been keeping up with hook commit activity. All the versions have been properly pinned down (including tink-worker being kept in sync with tink-server and tink-cli).

## How Has This Been Tested?

Both `vagrant up` and `terraform apply` have been run and work.