### PR TITLE
Use a stable image for tink-server, tink-worker and tink-cli

### DIFF
--- a/deploy/compose/.env
+++ b/deploy/compose/.env
@@ -1,7 +1,7 @@
 # These must be defined above/before first use.
 # Use of these variables *must* be in ${} form, otherwise docker-compose won't substitute when processing this file
 vOSIE=v0.7.0
-vTINK=sha-0a800a4b
+vTINK=sha-16186501
 
 # Probably don't want to mess with these, unless you know you do
 FACILITY=onprem


### PR DESCRIPTION
## Description
The current image that is used in the main branch doesn't work due to the issue which is reported here: https://github.com/tinkerbell/sandbox/issues/143. There was a PR which addressed this issue already which can be found here https://github.com/tinkerbell/tink/pull/632. This PR uses the latest `tink-server`, `tink-worker` and `tink-cli` which has the fix already in place. 
<!--- Please describe what this PR is going to change -->

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Checked out the main branch  
- Update the env var `vTINK` to `sha-16186501` 
- Run docker compose 
- Provision all the needed manifests(HW, WFL, TPL) 
- Reboot the machine 

## How are existing users impacted? What migration steps/scripts do we need?
I haven't updated any other components or image except the tink image.
<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
