### PR TITLE
Updated the sandbox links to Templates, Workflows, and Hardware Data

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ Tinkerbell.org has a [list of guides](https://docs.tinkerbell.org/deploying-oper
 You can also create your own.
 The following docs will help you get started.
 
-1. [Create Hardware Data](https://docs.tinkerbell.org/setup/local-vagrant/#creating-the-workers-hardware-data)
-2. [Create a Template](https://docs.tinkerbell.org/setup/local-vagrant/#creating-a-template)
-3. [Create a Workflow](https://docs.tinkerbell.org/setup/local-vagrant/#creating-the-workflow)
+1. [Create Hardware Data](https://docs.tinkerbell.org/hardware-data/)
+2. [Create a Template](https://docs.tinkerbell.org/templates/)
+3. [Create a Workflow](https://docs.tinkerbell.org/workflows/working-with-workflows/)
 
 ### In the Sandbox
 


### PR DESCRIPTION
Updated documentation links that were dead. First commit so please take it easy on me. Still learning the ropes here. I am also not sure if the workflows link is the right one as there are two workflow doc links on the tinkerbell site. Happy to change it if needed. 
<!--- Please describe what this PR is going to change -->

The old links no longer worked. 

<!--- Link to issue you have raised -->

Fixes #149 

## How Has This Been Tested?
I clicked the links to the new documentation. 

## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ x] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
