### PR TITLE
[stack/compose] Remove Hegel command arg that is deprecated:

### DIFF
--- a/deploy/stack/compose/docker-compose.yml
+++ b/deploy/stack/compose/docker-compose.yml
@@ -70,7 +70,6 @@ services:
 
   hegel:
     image: $HEGEL_IMAGE
-    command: ["--grpc-use-tls=false"]
     environment:
       HEGEL_KUBECONFIG: /output/kubeconfig.yaml
       HEGEL_KUBERNETES: "https://k3s:6443"


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
This command arg is no longer used Hegel v0.8.0 and prevents Hegel from starting up properly.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
