### PR TITLE
Add chrisdoherty4 as maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-/.github/settings.yml @jacobweinstock @mmlb
-/.github/CODEOWNERS @jacobweinstock @mmlb
+/.github/settings.yml @jacobweinstock @mmlb @chrisdoherty4
+/.github/CODEOWNERS @jacobweinstock @mmlb @chrisdoherty4

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -6,6 +6,8 @@ collaborators:
     permission: maintain
   - username: mmlb
     permission: maintain
+  - username: chrisdoherty4
+    permission: maintain
   # Approvers
   - username: detiber
     permission: push


### PR DESCRIPTION
Add myself as a maintainer to Sandbox. 

Having discussed with a @jacobweinstock and @displague we concluded it was appropriate to add maintainers of various Tinkerbell services to Sandbox so we can keep it up-to-date and help triage issues.