### PR TITLE
Use github pages to server vagrantbox metadata:

### DIFF
--- a/.github/workflows/pxe-box-release.yaml
+++ b/.github/workflows/pxe-box-release.yaml
@@ -69,15 +69,32 @@ jobs:
             - commit: `${{ github.sha }}`
             - built by: ${{ github.workflow }} (${{ github.run_id }})
 
+            `metadata.json` is published to GitHub Pages — Vagrant requires
+            a `Content-Type: application/json` response, which Release assets
+            cannot provide (they're served as `application/octet-stream`).
+
             Use it from a `Vagrantfile`:
 
             ```ruby
             config.vm.box     = "tinkerbell/pxe"
-            config.vm.box_url = "https://github.com/${{ github.repository }}/releases/download/${{ env.RELEASE_TAG }}/metadata.json"
+            config.vm.box_url = "https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/pxe-box/metadata.json"
             ```
           files: |
             stack/pxe-box/out/pxe-amd64-virtualbox.box
             stack/pxe-box/out/pxe-arm64-virtualbox.box
             stack/pxe-box/out/pxe-amd64-libvirt.box
             stack/pxe-box/out/pxe-arm64-libvirt.box
-            stack/pxe-box/out/metadata.json
+
+      - name: Stage metadata.json for GitHub Pages
+        run: |
+          mkdir -p pages-publish/pxe-box
+          cp stack/pxe-box/out/metadata.json pages-publish/pxe-box/metadata.json
+
+      - name: Publish metadata.json to gh-pages branch
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: pages-publish
+          publish_branch: gh-pages
+          keep_files: true
+          commit_message: "pxe-box: publish metadata.json (${{ github.sha }})"

--- a/stack/pxe-box/scripts/make-metadata.sh
+++ b/stack/pxe-box/scripts/make-metadata.sh
@@ -20,25 +20,25 @@ cat <<JSON
           "name": "virtualbox",
           "architecture": "amd64",
           "default_architecture": true,
-          "url": "$base_url/$version/pxe-amd64-virtualbox.box"
+          "url": "$base_url/pxe-amd64-virtualbox.box"
         },
         {
           "name": "virtualbox",
           "architecture": "arm64",
           "default_architecture": false,
-          "url": "$base_url/$version/pxe-arm64-virtualbox.box"
+          "url": "$base_url/pxe-arm64-virtualbox.box"
         },
         {
           "name": "libvirt",
           "architecture": "amd64",
           "default_architecture": true,
-          "url": "$base_url/$version/pxe-amd64-libvirt.box"
+          "url": "$base_url/pxe-amd64-libvirt.box"
         },
         {
           "name": "libvirt",
           "architecture": "arm64",
           "default_architecture": false,
-          "url": "$base_url/$version/pxe-arm64-libvirt.box"
+          "url": "$base_url/pxe-arm64-libvirt.box"
         }
       ]
     }

--- a/stack/pxe-box/scripts/pack-virtualbox.sh
+++ b/stack/pxe-box/scripts/pack-virtualbox.sh
@@ -13,12 +13,14 @@ case "$arch" in
 amd64)
 	ostype=Ubuntu_64
 	platform=x86
-	chipset=ich9
+	platform_block='<x86/>'
+	chipset=PIIX3
 	gfx=VBoxVGA
 	;;
 arm64)
 	ostype=Ubuntu_arm64
 	platform=ARM
+	platform_block='<arm/>'
 	chipset=ARMv8Virtual
 	gfx=QemuRamFB
 	;;
@@ -47,6 +49,7 @@ sed \
 	-e "s|@@DISK_BYTES@@|$disk_bytes|g" \
 	-e "s|@@OSTYPE@@|$ostype|g" \
 	-e "s|@@PLATFORM@@|$platform|g" \
+	-e "s|@@PLATFORM_BLOCK@@|$platform_block|g" \
 	-e "s|@@CHIPSET@@|$chipset|g" \
 	-e "s|@@GFX@@|$gfx|g" \
 	"$here/templates/box.ovf.tmpl" >"$work/box.ovf"

--- a/stack/pxe-box/templates/box.ovf.tmpl
+++ b/stack/pxe-box/templates/box.ovf.tmpl
@@ -5,10 +5,15 @@
     @@UUID@@         VM UUID
     @@DISK_UUID@@    UUID of the disk image
     @@DISK_BYTES@@   raw size in bytes of the .vmdk's source
-    @@OSTYPE@@       Ubuntu_64 | Ubuntu_arm64
-    @@PLATFORM@@     x86 | ARM        (case matters; matches VBox 7.1 export)
-    @@CHIPSET@@      ich9 | ARMv8Virtual
-    @@GFX@@          VBoxVGA | QemuRamFB  (arm64 cannot use VGA -> VERR_PGM_RAM_CONFLICT)
+    @@OSTYPE@@         Ubuntu_64 | Ubuntu_arm64
+    @@PLATFORM@@       x86 | ARM        (case matters; matches VBox 7.1 export)
+    @@PLATFORM_BLOCK@@ <x86/> | <arm/>
+                       (required <Platform> child element on VBox 7.2+)
+    @@CHIPSET@@        PIIX3 | ARMv8Virtual
+                       (PIIX3 chosen for amd64 to avoid VBox 7.2 OVF-import
+                       gap where ICH9 needs IOAPIC but the imported XML's
+                       <x86><APIC/></x86> isn't honored at runtime)
+    @@GFX@@            VBoxVGA | QemuRamFB  (arm64 cannot use VGA -> VERR_PGM_RAM_CONFLICT)
 
   Structure mirrors the output of `VBoxManage export` on a working arm64
   VM. Notably, `<Platform>` lives inside `<vbox:Machine>` as a sibling of
@@ -146,6 +151,7 @@
         </StorageControllers>
       </Hardware>
       <Platform architecture="@@PLATFORM@@">
+        @@PLATFORM_BLOCK@@
         <RTC localOrUTC="UTC"/>
         <Chipset type="@@CHIPSET@@"/>
         <CPU/>


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
The content type in GitHub releases for all files is application/octet-stream. Vagrant requires the box metadata to be of content type: application/json

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack, etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
