### PR TITLE
fix image-stream race:

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,6 +1,10 @@
+merge_queue:
+  max_parallel_checks: 1
 queue_rules:
   - name: default
+    batch_size: 1
     queue_conditions:
+      - -draft
       - base=main
       - or:
           - "#approved-reviews-by>=1"
@@ -23,16 +27,13 @@ queue_rules:
       - check-success=build
       - label!=do-not-merge
       - label=ready-to-merge
+      # This extra condition forces draft PR mode (prevents in-place checks)
+      - queue-position>=0
     commit_message_template: |
       {{ title }} (#{{ number }})
 
       {{ body }}
     merge_method: merge
 
-pull_request_rules:
-  - name: Automatic merge on approval
-    conditions: []
-    actions:
-      queue:
 merge_protections_settings:
   reporting_method: check-runs

--- a/stack/vagrant/template.yaml
+++ b/stack/vagrant/template.yaml
@@ -28,7 +28,7 @@ spec:
               FS_TYPE: ext4
               CHROOT: y
               DEFAULT_INTERPRETER: "/bin/sh -c"
-              CMD_LINE: "growpart {{ index .Hardware.Disks 0 }} 1 && resize2fs {{ formatPartition ( index .Hardware.Disks 0 ) 1 }}"
+              CMD_LINE: "sleep 5 && growpart {{ index .Hardware.Disks 0 }} 1 && resize2fs {{ formatPartition ( index .Hardware.Disks 0 ) 1 }}"
           - name: "install openssl"
             image: quay.io/tinkerbell/actions/cexec:latest
             timeout: 90


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
After image2disk streams the cloud image to /dev/sda, the kernel and udev occasionally haven't re-read the new partition table by the time the next cexec action opens /dev/sda1, causing mount to fail with EINVAL and the workflow to fail intermittently (re-runs succeed). The race is more likely on the VirtualBox stack where the arm64 image2disk finishes in ~5s, leaving only milliseconds before grow-partition runs. A short sleep gives the partition rescan time to settle.

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack, etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
